### PR TITLE
config: 공통 설정 부 모듈화

### DIFF
--- a/porko-common/build.gradle.kts
+++ b/porko-common/build.gradle.kts
@@ -10,4 +10,5 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0")
     implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("org.springframework.boot:spring-boot-starter-web")
 }

--- a/porko-common/build.gradle.kts
+++ b/porko-common/build.gradle.kts
@@ -8,4 +8,5 @@ repositories {
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0")
 }

--- a/porko-common/build.gradle.kts
+++ b/porko-common/build.gradle.kts
@@ -11,4 +11,6 @@ dependencies {
     implementation("com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-web")
+
+    testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter:1.0.14")
 }

--- a/porko-common/build.gradle.kts
+++ b/porko-common/build.gradle.kts
@@ -9,4 +9,5 @@ repositories {
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0")
+    implementation("org.springframework.boot:spring-boot-starter-security")
 }

--- a/porko-common/build.gradle.kts
+++ b/porko-common/build.gradle.kts
@@ -1,0 +1,11 @@
+val bootJar: org.springframework.boot.gradle.tasks.bundling.BootJar by tasks
+
+bootJar.enabled = false
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+}

--- a/porko-common/src/main/java/io/porko/PorkoCommonConfig.java
+++ b/porko-common/src/main/java/io/porko/PorkoCommonConfig.java
@@ -1,0 +1,9 @@
+package io.porko;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+
+@ComponentScan
+@EnableAutoConfiguration
+public abstract class PorkoCommonConfig {
+}

--- a/porko-common/src/main/java/io/porko/config/jpa/JpaConfig.java
+++ b/porko-common/src/main/java/io/porko/config/jpa/JpaConfig.java
@@ -1,0 +1,9 @@
+package io.porko.config.jpa;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing(modifyOnCreate = false)
+public class JpaConfig {
+}

--- a/porko-common/src/main/java/io/porko/config/jpa/auditor/MetaFields.java
+++ b/porko-common/src/main/java/io/porko/config/jpa/auditor/MetaFields.java
@@ -1,0 +1,18 @@
+package io.porko.config.jpa.auditor;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+
+@Getter
+@MappedSuperclass
+public abstract class MetaFields extends TimeMetaFields {
+    @Column(updatable = false)
+    @CreatedBy
+    private Long createdBy;
+
+    @LastModifiedBy
+    private Long updatedBy;
+}

--- a/porko-common/src/main/java/io/porko/config/jpa/auditor/TimeMetaFields.java
+++ b/porko-common/src/main/java/io/porko/config/jpa/auditor/TimeMetaFields.java
@@ -1,0 +1,24 @@
+package io.porko.config.jpa.auditor;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@Embeddable
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class TimeMetaFields {
+    @Column(nullable = false, updatable = false)
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/porko-common/src/main/java/io/porko/config/security/PasswordEncoderConfig.java
+++ b/porko-common/src/main/java/io/porko/config/security/PasswordEncoderConfig.java
@@ -1,0 +1,14 @@
+package io.porko.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+    @Bean
+    public PasswordEncoder delegatePasswordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+}

--- a/porko-common/src/main/java/io/porko/config/security/SecurityConfig.java
+++ b/porko-common/src/main/java/io/porko/config/security/SecurityConfig.java
@@ -1,0 +1,32 @@
+package io.porko.config.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+            .formLogin(AbstractHttpConfigurer::disable)
+            .httpBasic(AbstractHttpConfigurer::disable)
+            .csrf(AbstractHttpConfigurer::disable)
+            .headers(headersConfigurer -> headersConfigurer
+                .frameOptions(FrameOptionsConfig::disable)
+            )
+            .sessionManagement(sessionManagementConfigurer -> sessionManagementConfigurer
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            )
+            .authorizeHttpRequests(auth -> auth
+                .anyRequest().permitAll()
+            )
+            .build();
+    }
+}

--- a/porko-common/src/main/java/io/porko/exception/BusinessException.java
+++ b/porko-common/src/main/java/io/porko/exception/BusinessException.java
@@ -1,0 +1,17 @@
+package io.porko.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public abstract class BusinessException extends RuntimeException {
+    protected HttpStatus status;
+    private final String code;
+    private final String message;
+
+    public BusinessException(HttpStatus status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/porko-common/src/main/java/io/porko/exception/handler/BaseExceptionHandler.java
+++ b/porko-common/src/main/java/io/porko/exception/handler/BaseExceptionHandler.java
@@ -1,0 +1,65 @@
+package io.porko.exception.handler;
+
+import io.porko.exception.BusinessException;
+import io.porko.exception.response.ErrorCode;
+import io.porko.exception.response.ErrorResponse;
+import io.porko.exception.response.invalid.MethodArgumentNotValidErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpMediaTypeNotAcceptableException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingPathVariableException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@RestControllerAdvice
+public class BaseExceptionHandler {
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> businessException(
+        BusinessException exception,
+        HttpServletRequest request
+    ) {
+        return ResponseEntity.status(exception.getStatus())
+            .body(ErrorResponse.businessErrorOf(
+                request,
+                exception
+            ));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> methodArgumentNotValidException(
+        MethodArgumentNotValidException exception,
+        HttpServletRequest request
+    ) {
+        return ResponseEntity.badRequest()
+            .body(MethodArgumentNotValidErrorResponse.of(
+                request,
+                ErrorCode.METHOD_ARGUMENT_NOT_VALID,
+                exception.getFieldErrors()
+            ));
+    }
+
+    @ExceptionHandler({
+        HttpMessageNotReadableException.class,
+        MethodArgumentTypeMismatchException.class,
+        HttpRequestMethodNotSupportedException.class,
+        HttpMediaTypeNotAcceptableException.class,
+        HttpMediaTypeNotSupportedException.class,
+        MissingPathVariableException.class,
+        MissingServletRequestParameterException.class
+    })
+    public ResponseEntity<ErrorResponse> invalidRequestException(Exception exception, HttpServletRequest request) {
+        ErrorCode errorCode = ErrorCode.valueOf(exception);
+        return ResponseEntity
+            .status(errorCode.status)
+            .body(ErrorResponse.of(
+                request,
+                errorCode)
+            );
+    }
+}

--- a/porko-common/src/main/java/io/porko/exception/handler/UnexpectedExceptionHandler.java
+++ b/porko-common/src/main/java/io/porko/exception/handler/UnexpectedExceptionHandler.java
@@ -1,0 +1,17 @@
+package io.porko.exception.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class UnexpectedExceptionHandler {
+    // TODO: 예상하지 못한 예외 발생 시, 알림 발생 이벤트 발행 및 printStackTrace() 제거
+    @ExceptionHandler({Exception.class, RuntimeException.class})
+    public ResponseEntity<?> unexpectedException(Exception exception, HttpServletRequest request) {
+        exception.printStackTrace();
+        return ResponseEntity.internalServerError()
+            .body(null);
+    }
+}

--- a/porko-common/src/main/java/io/porko/exception/response/ErrorCode.java
+++ b/porko-common/src/main/java/io/porko/exception/response/ErrorCode.java
@@ -1,0 +1,56 @@
+package io.porko.exception.response;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.UNSUPPORTED_MEDIA_TYPE;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+    HTTP_MESSAGE_NOT_READABLE(BAD_REQUEST, "요청 값을 확인 할 수 없습니다. 요청 값을 확인해 주세요."),
+    METHOD_ARGUMENT_TYPE_MISMATCH(BAD_REQUEST, "요청 값의 자료형이 잘못되었습니다. 요청 값을 확인해 주세요."),
+    METHOD_ARGUMENT_NOT_VALID(BAD_REQUEST, "잘못된 요청입니다. 요청 값을 확인해 주세요."),
+    MISSING_SERVLET_REQUEST_PARAMETER(BAD_REQUEST, "잘못된 요청입니다. 요청 값을 확인해 주세요."),
+    MISSING_SERVLET_PATH_VARIABLE(BAD_REQUEST, "잘못된 요청입니다. 요청 값을 확인해 주세요."),
+    HTTP_MEDIA_TYPE_NOT_SUPPORTED(UNSUPPORTED_MEDIA_TYPE, "지원하지 않는 Media Type입니다."),
+
+    UNEXPECTED_ERROR(INTERNAL_SERVER_ERROR, "알 수 없는 오류가 발생하였습니다.");
+
+    public final HttpStatus status;
+    public final String message;
+
+    ErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public static ErrorCode valueOf(Exception exception) {
+        String errorCodeName = convertExceptionClassNameToErrorCodeName(exception);
+        try {
+            return valueOf(errorCodeName);
+        } catch (IllegalArgumentException e) {
+            return ErrorCode.UNEXPECTED_ERROR;
+        }
+    }
+
+    private static String convertExceptionClassNameToErrorCodeName(Exception exception) {
+        String className = extractExceptionClassName(exception);
+        return convertToErrorCodeName(className);
+    }
+
+    private static String extractExceptionClassName(Exception exception) {
+        return exception.getClass().getSimpleName();
+    }
+
+    private static String convertToErrorCodeName(String className) {
+        String regex = "([a-z])([A-Z])";
+        String replacement = "$1_$2";
+        String exceptKeyword = "_Exception";
+
+        return className.replaceAll(regex, replacement)
+            .replace(exceptKeyword, "")
+            .toUpperCase();
+    }
+}

--- a/porko-common/src/main/java/io/porko/exception/response/ErrorResponse.java
+++ b/porko-common/src/main/java/io/porko/exception/response/ErrorResponse.java
@@ -1,0 +1,42 @@
+package io.porko.exception.response;
+
+import io.porko.exception.BusinessException;
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
+
+@Getter
+public class ErrorResponse {
+    private final String method;
+    private final String path;
+    private final String code;
+    private final String message;
+
+    @DateTimeFormat(iso = ISO.DATE_TIME)
+    private final LocalDateTime timestamp = LocalDateTime.now();
+
+    private ErrorResponse(HttpServletRequest request, String code, String message) {
+        this.method = request.getMethod();
+        this.path = request.getRequestURI();
+        this.code = code;
+        this.message = message;
+    }
+
+    protected ErrorResponse(HttpServletRequest request, ErrorCode errorCode) {
+        this(request, errorCode.name(), errorCode.message);
+    }
+
+    private ErrorResponse(HttpServletRequest request, BusinessException exception) {
+        this(request, exception.getCode(), exception.getMessage());
+    }
+
+    public static ErrorResponse businessErrorOf(HttpServletRequest request, BusinessException exception) {
+        return new ErrorResponse(request, exception);
+    }
+
+    public static ErrorResponse of(HttpServletRequest request, ErrorCode errorCode) {
+        return new ErrorResponse(request, errorCode);
+    }
+}

--- a/porko-common/src/main/java/io/porko/exception/response/invalid/ErrorDetail.java
+++ b/porko-common/src/main/java/io/porko/exception/response/invalid/ErrorDetail.java
@@ -1,0 +1,13 @@
+package io.porko.exception.response.invalid;
+
+public record ErrorDetail(
+    String object,
+    String field,
+    String code,
+    String RejectValue,
+    Object rejectMessage
+) {
+    public static ErrorDetail of(String object, String field, String code, String RejectValue, Object rejectMessage) {
+        return new ErrorDetail(object, field, code, RejectValue, rejectMessage);
+    }
+}

--- a/porko-common/src/main/java/io/porko/exception/response/invalid/ErrorDetails.java
+++ b/porko-common/src/main/java/io/porko/exception/response/invalid/ErrorDetails.java
@@ -1,0 +1,23 @@
+package io.porko.exception.response.invalid;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.validation.FieldError;
+
+public record ErrorDetails(
+    List<ErrorDetail> elements
+) {
+    public static ErrorDetails from(List<FieldError> fieldErrors) {
+        return new ErrorDetails(
+            fieldErrors.stream()
+                .map(fieldError -> ErrorDetail.of(
+                    fieldError.getObjectName(),
+                    fieldError.getField(),
+                    fieldError.getCode(),
+                    fieldError.getDefaultMessage(),
+                    fieldError.getRejectedValue()
+                ))
+                .collect(Collectors.toList())
+        );
+    }
+}

--- a/porko-common/src/main/java/io/porko/exception/response/invalid/MethodArgumentNotValidErrorResponse.java
+++ b/porko-common/src/main/java/io/porko/exception/response/invalid/MethodArgumentNotValidErrorResponse.java
@@ -1,0 +1,34 @@
+package io.porko.exception.response.invalid;
+
+import io.porko.exception.response.ErrorCode;
+import io.porko.exception.response.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import lombok.Getter;
+import org.springframework.validation.FieldError;
+
+@Getter
+public class MethodArgumentNotValidErrorResponse extends ErrorResponse {
+    private final ErrorDetails errorDetails;
+
+    private MethodArgumentNotValidErrorResponse(
+        HttpServletRequest request,
+        ErrorCode errorCode,
+        ErrorDetails errorDetails
+    ) {
+        super(request, errorCode);
+        this.errorDetails = errorDetails;
+    }
+
+    public static MethodArgumentNotValidErrorResponse of(
+        HttpServletRequest request,
+        ErrorCode basicErrorCode,
+        List<FieldError> fieldErrors
+    ) {
+        return new MethodArgumentNotValidErrorResponse(
+            request,
+            basicErrorCode,
+            ErrorDetails.from(fieldErrors)
+        );
+    }
+}

--- a/porko-common/src/main/resources/application.yml
+++ b/porko-common/src/main/resources/application.yml
@@ -1,0 +1,8 @@
+spring:
+  config:
+    import:
+      - classpath:properties/datasource.yml
+      - classpath:properties/jpa.yml
+  profiles:
+    group:
+      test: h2-test, jpa-test

--- a/porko-common/src/main/resources/properties/datasource.yml
+++ b/porko-common/src/main/resources/properties/datasource.yml
@@ -1,0 +1,18 @@
+spring:
+  datasource:
+    hikari:
+      maximum-pool-size: 10
+      max-lifetime: 30000
+      connection-timeout: 3000
+---
+spring:
+  config.activate.on-profile: h2-test
+  datasource:
+    platform: mysql
+    hikari:
+      jdbc-url: jdbc:h2:mem:test_db;MODE=MySql
+    username: sa
+    password:
+  test.database.replace: none
+  sql.init.mode: never
+---

--- a/porko-common/src/main/resources/properties/jpa.yml
+++ b/porko-common/src/main/resources/properties/jpa.yml
@@ -1,0 +1,15 @@
+spring:
+  jpa:
+    open-in-view: false
+    properties:
+      hibernate:
+        default_batch_fetch_size: 1000
+---
+spring:
+  config.activate.on-profile: jpa-test
+  jpa:
+    database: mysql
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    defer-datasource-initialization: true
+    hibernate:
+      ddl-auto: create-drop

--- a/porko-common/src/test/java/io/porko/config/base/TestBase.java
+++ b/porko-common/src/test/java/io/porko/config/base/TestBase.java
@@ -1,0 +1,13 @@
+package io.porko.config.base;
+
+import static io.porko.config.base.TestBase.TEST;
+
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.test.context.TestConstructor.AutowireMode;
+
+@ActiveProfiles(TEST)
+@TestConstructor(autowireMode = AutowireMode.ALL)
+public abstract class TestBase {
+    static final String TEST = "test";
+}

--- a/porko-common/src/test/java/io/porko/config/base/business/ServiceTestBase.java
+++ b/porko-common/src/test/java/io/porko/config/base/business/ServiceTestBase.java
@@ -1,0 +1,9 @@
+package io.porko.config.base.business;
+
+import io.porko.config.base.TestBase;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public abstract class ServiceTestBase extends TestBase {
+}

--- a/porko-common/src/test/java/io/porko/config/base/persistence/DatasourceTestConfig.java
+++ b/porko-common/src/test/java/io/porko/config/base/persistence/DatasourceTestConfig.java
@@ -1,0 +1,16 @@
+package io.porko.config.base.persistence;
+
+import com.github.gavlyukovskiy.boot.jdbc.decorator.DataSourceDecoratorAutoConfiguration;
+import io.porko.config.base.TestBase;
+import io.porko.config.jpa.TestJpaConfiguration;
+import io.porko.config.p6spy.P6spySqlFormatConfiguration;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.context.annotation.Import;
+
+@Import({
+    TestJpaConfiguration.class,
+    P6spySqlFormatConfiguration.class
+})
+@ImportAutoConfiguration(DataSourceDecoratorAutoConfiguration.class)
+public abstract class DatasourceTestConfig extends TestBase {
+}

--- a/porko-common/src/test/java/io/porko/config/base/persistence/JpaTestBase.java
+++ b/porko-common/src/test/java/io/porko/config/base/persistence/JpaTestBase.java
@@ -1,0 +1,7 @@
+package io.porko.config.base.persistence;
+
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest(showSql = false)
+public abstract class JpaTestBase extends DatasourceTestConfig {
+}

--- a/porko-common/src/test/java/io/porko/config/base/presentation/RequestBuilder.java
+++ b/porko-common/src/test/java/io/porko/config/base/presentation/RequestBuilder.java
@@ -1,0 +1,197 @@
+package io.porko.config.base.presentation;
+
+import static org.springframework.http.HttpMethod.DELETE;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpMethod.PUT;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+public class RequestBuilder {
+    private final MockMvc mockMvc;
+
+    private final ObjectMapper objectMapper;
+
+    private String url;
+
+    private List<Object> urlVariables;
+
+    private HttpMethod method;
+
+    private final Map<String, Object> headers = new HashMap<>();
+    private MediaType contentType;
+
+    private Object content;
+
+    private HttpStatus status;
+
+    private RequestBuilder(final MockMvc mockMvc, final ObjectMapper mapper) {
+        this.mockMvc = mockMvc;
+        this.objectMapper = mapper;
+        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+    }
+
+    public static EndPoint get(final MockMvc mockMvc, final ObjectMapper objectMapper) {
+        return new RequestBuilder(mockMvc, objectMapper)
+            .request()
+            .get();
+    }
+
+    public static EndPoint post(final MockMvc mockMvc, final ObjectMapper objectMapper) {
+        return new RequestBuilder(mockMvc, objectMapper)
+            .request()
+            .post();
+    }
+
+    public static EndPoint put(final MockMvc mockMvc, final ObjectMapper objectMapper) {
+        return new RequestBuilder(mockMvc, objectMapper)
+            .request()
+            .put();
+    }
+
+    public static EndPoint delete(final MockMvc mockMvc, final ObjectMapper objectMapper) {
+        return new RequestBuilder(mockMvc, objectMapper)
+            .request()
+            .delete();
+    }
+
+    private Method request() {
+        return new Method();
+    }
+
+    public class Method {
+        public EndPoint method(final HttpMethod methodInput) {
+            method = methodInput;
+            return new EndPoint();
+        }
+
+        public EndPoint get() {
+            method = GET;
+            return new EndPoint();
+        }
+
+        public EndPoint post() {
+            method = POST;
+            return new EndPoint();
+        }
+
+        public EndPoint put() {
+            method = PUT;
+            return new EndPoint();
+        }
+
+        public EndPoint delete() {
+            method = DELETE;
+            return new EndPoint();
+        }
+    }
+
+    public class EndPoint {
+        public Content url(final String urlInput, final Object... urlVariablesInput) {
+            url = urlInput;
+            urlVariables = Arrays.asList(urlVariablesInput);
+            return new Content();
+        }
+    }
+
+    public class Content {
+        public Expect jsonContent(final Object object) {
+            contentType = MediaType.APPLICATION_JSON;
+            content = object;
+            return new Expect();
+        }
+
+        public Expect expect() {
+            return new Expect();
+        }
+    }
+
+    public class Expect {
+        public ResultActions expectStatus(HttpStatus expectStatus) throws Exception {
+            status = expectStatus;
+            return makeRequest();
+        }
+
+        public ResultActions ok() throws Exception {
+            status = HttpStatus.OK;
+            return makeRequest();
+        }
+
+        public ResultActions noContent() throws Exception {
+            status = HttpStatus.NO_CONTENT;
+            return makeRequest();
+        }
+
+        public ResultActions created() throws Exception {
+            status = HttpStatus.CREATED;
+            return makeRequest();
+        }
+
+        public ResultActions unAuthorized() throws Exception {
+            status = HttpStatus.UNAUTHORIZED;
+            return makeRequest();
+        }
+
+        public ResultActions forbidden() throws Exception {
+            status = HttpStatus.FORBIDDEN;
+            return makeRequest();
+        }
+
+        public ResultActions badRequest() throws Exception {
+            status = HttpStatus.BAD_REQUEST;
+            return makeRequest();
+        }
+
+        public ResultActions notFound() throws Exception {
+            status = HttpStatus.NOT_FOUND;
+            return makeRequest();
+        }
+
+        public ResultActions conflict() throws Exception {
+            status = HttpStatus.CONFLICT;
+            return makeRequest();
+        }
+    }
+
+    /**
+     * TODO : TC 기반 API docs 추출 시 RequestBuilder 변경
+     * - as-is :MockMvcRequestBuilders
+     * - to-be : RestDocumentationRequestBuilders
+     */
+    private ResultActions makeRequest() throws Exception {
+        MockHttpServletRequestBuilder request =
+            MockMvcRequestBuilders.request(
+                method,
+                url,
+                urlVariables.toArray()
+            );
+
+        for (String header : headers.keySet()) {
+            request.header(header, headers.get(header));
+        }
+
+        if (content != null) {
+            request.contentType(contentType)
+                .content(objectMapper.writeValueAsString(content));
+        }
+
+        return mockMvc.perform(request)
+            .andDo(print())
+            .andExpect(status().is(status.value()));
+    }
+}

--- a/porko-common/src/test/java/io/porko/config/base/presentation/WebMvcTestBase.java
+++ b/porko-common/src/test/java/io/porko/config/base/presentation/WebMvcTestBase.java
@@ -1,0 +1,44 @@
+package io.porko.config.base.presentation;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.porko.config.base.TestBase;
+import io.porko.config.security.TestSecurityConfig;
+import jakarta.annotation.Resource;
+import java.io.UnsupportedEncodingException;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@Import(TestSecurityConfig.class)
+public abstract class WebMvcTestBase extends TestBase {
+    @Resource
+    protected MockMvc mockMvc;
+    @Resource
+    protected ObjectMapper objectMapper;
+
+    protected RequestBuilder.EndPoint get() {
+        return RequestBuilder.get(mockMvc, objectMapper);
+    }
+
+    protected RequestBuilder.EndPoint post() {
+        return RequestBuilder.post(mockMvc, objectMapper);
+    }
+
+    protected RequestBuilder.EndPoint put() {
+        return RequestBuilder.put(mockMvc, objectMapper);
+    }
+
+    protected RequestBuilder.EndPoint delete() {
+        return RequestBuilder.delete(mockMvc, objectMapper);
+    }
+
+    protected <T> T andReturn(ResultActions resultActions, Class<T> clazz)
+        throws UnsupportedEncodingException, JsonProcessingException {
+        return objectMapper.readValue(extractResponseBody(resultActions), clazz);
+    }
+
+    private String extractResponseBody(ResultActions resultActions) throws UnsupportedEncodingException {
+        return resultActions.andReturn().getResponse().getContentAsString();
+    }
+}

--- a/porko-common/src/test/java/io/porko/config/fixture/FixtureCommon.java
+++ b/porko-common/src/test/java/io/porko/config/fixture/FixtureCommon.java
@@ -1,0 +1,40 @@
+package io.porko.config.fixture;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.FixtureMonkeyBuilder;
+import com.navercorp.fixturemonkey.api.introspector.BuilderArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
+import com.navercorp.fixturemonkey.jakarta.validation.plugin.JakartaValidationPlugin;
+
+public class FixtureCommon {
+    private static final FixtureMonkeyBuilder builder = FixtureMonkey.builder();
+
+    public static FixtureMonkey entityType() {
+        return builder
+            .objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
+            .defaultNotNull(true)
+            .build();
+    }
+
+    public static FixtureMonkey dtoType() {
+        return builder
+            .objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
+            .defaultNotNull(true)
+            .build();
+    }
+
+    public static FixtureMonkey withValidated() {
+        return builder
+            .objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
+            .defaultNotNull(true)
+            .plugin(new JakartaValidationPlugin())
+            .build();
+    }
+
+    public static FixtureMonkey builderType() {
+        return builder
+            .objectIntrospector(BuilderArbitraryIntrospector.INSTANCE)
+            .build();
+    }
+}

--- a/porko-common/src/test/java/io/porko/config/jpa/TestJpaConfiguration.java
+++ b/porko-common/src/test/java/io/porko/config/jpa/TestJpaConfiguration.java
@@ -3,6 +3,7 @@ package io.porko.config.jpa;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+// TODO: Test 환경에서 사용할 사용자 정보를 통해 AuditingListener가 설정할 메타 데이터 제공
 @TestConfiguration
 @EnableJpaAuditing(modifyOnCreate = false)
 public class TestJpaConfiguration {

--- a/porko-common/src/test/java/io/porko/config/jpa/TestJpaConfiguration.java
+++ b/porko-common/src/test/java/io/porko/config/jpa/TestJpaConfiguration.java
@@ -1,0 +1,9 @@
+package io.porko.config.jpa;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@TestConfiguration
+@EnableJpaAuditing(modifyOnCreate = false)
+public class TestJpaConfiguration {
+}

--- a/porko-common/src/test/java/io/porko/config/p6spy/P6spySqlFormatConfiguration.java
+++ b/porko-common/src/test/java/io/porko/config/p6spy/P6spySqlFormatConfiguration.java
@@ -1,0 +1,87 @@
+package io.porko.config.p6spy;
+
+import com.p6spy.engine.common.ConnectionInformation;
+import com.p6spy.engine.event.JdbcEventListener;
+import com.p6spy.engine.logging.Category;
+import com.p6spy.engine.spy.P6SpyOptions;
+import com.p6spy.engine.spy.appender.MessageFormattingStrategy;
+import java.sql.SQLException;
+import java.util.Locale;
+import org.hibernate.engine.jdbc.internal.FormatStyle;
+import org.hibernate.engine.jdbc.internal.Formatter;
+import org.springframework.boot.test.context.TestComponent;
+
+@TestComponent
+public class P6spySqlFormatConfiguration extends JdbcEventListener implements MessageFormattingStrategy {
+    public static final String CREATE = "create";
+    public static final String ALTER = "alter";
+    public static final String COMMENT = "comment";
+    public static final String EXECUTE_QUERY_LOG_FORMAT = "\n[Connection : %s][%s][%d ms] %s";
+
+    @Override
+    public void onAfterGetConnection(ConnectionInformation connectionInformation, SQLException e) {
+        P6SpyOptions.getActiveInstance().setLogMessageFormat(getClass().getName());
+    }
+
+    @Override
+    public String formatMessage(
+        int connectionId,
+        String now,
+        long duration,
+        String category,
+        String prepared,
+        String sql,
+        String url
+    ) {
+        return String.format(
+            EXECUTE_QUERY_LOG_FORMAT,
+            connectionId,
+            category,
+            duration,
+            formatSql(category, sql)
+        );
+    }
+
+    private String formatSql(String category, String sql) {
+        if (isNotStatementCategory(category)) {
+            return sql;
+        }
+        return formatSqlByStatementCategory(sql);
+    }
+
+    private boolean isNotStatementCategory(String category) {
+        return !isStatementCategory(category);
+    }
+
+    private boolean isStatementCategory(String category) {
+        return Category.STATEMENT.getName().equals(category);
+    }
+
+    private String formatSqlByStatementCategory(String sql) {
+        if (isDataDefinitionLanguage(sql)) {
+            return toFormat(FormatStyle.DDL, sql);
+        }
+        return applyHighlighter(toFormat(FormatStyle.BASIC, sql));
+    }
+
+    private boolean isDataDefinitionLanguage(String sql) {
+        String statement = toLowerCase(sql);
+        return statement.startsWith(CREATE) || statement.startsWith(ALTER) || statement.startsWith(COMMENT);
+    }
+
+    private String toLowerCase(String sql) {
+        return sql.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private String toFormat(FormatStyle formatStyle, String sql) {
+        return getFormatter(formatStyle).format(sql);
+    }
+
+    private Formatter getFormatter(FormatStyle formatStyle) {
+        return formatStyle.getFormatter();
+    }
+
+    private String applyHighlighter(String sql) {
+        return FormatStyle.HIGHLIGHT.getFormatter().format(sql);
+    }
+}

--- a/porko-common/src/test/java/io/porko/config/security/TestSecurityConfig.java
+++ b/porko-common/src/test/java/io/porko/config/security/TestSecurityConfig.java
@@ -1,0 +1,7 @@
+package io.porko.config.security;
+
+import org.springframework.context.annotation.Import;
+
+@Import(SecurityConfig.class)
+public class TestSecurityConfig {
+}

--- a/porko-common/src/test/java/io/porko/config/security/TestSecurityConfig.java
+++ b/porko-common/src/test/java/io/porko/config/security/TestSecurityConfig.java
@@ -2,6 +2,7 @@ package io.porko.config.security;
 
 import org.springframework.context.annotation.Import;
 
+// TODO: Mocking을 통해 인증된 사용자 정보 제공
 @Import(SecurityConfig.class)
 public class TestSecurityConfig {
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,2 @@
 rootProject.name = "porko"
+include("porko-common")


### PR DESCRIPTION
## #️⃣연관된 이슈

> #2 

## 📝작업 내용

- [JPA 관련 공통 설정 추가](https://github.com/project-porko/porko-service/commit/84d575530f73363d59cd57941389e88ee463a539)
- [JPA Test 관련 공통 설정 추가](https://github.com/project-porko/porko-service/commit/a57bd9021293e9668d89fc7bdf5388d0925523c2)
- [Spring Security 관련 공통 설정 추가](https://github.com/project-porko/porko-service/commit/e6e775c008ff38d188b40d85b6f2809a1f0fb3ed)
- [test 환경에서 인증/인가 처리를 위한 Security Test Config 설정](https://github.com/project-porko/porko-service/commit/dbc315490d7ac0d2167e75c1f6ebad2e5cb2e6dc)
- [service, facade 등 mocking을 이용한 business 계층 test 관련 설정 부 추가](https://github.com/project-porko/porko-service/commit/5c8b6fd00a3404d0010877d80a6c65eeaaeb80e7)
- [Exception 처리를 위한 Exception Handler](https://github.com/project-porko/porko-service/commit/b587d1f8e9364080d4abbea32abe75a38a4dc2eb)
- [Presentation 계층 Test 관련 공통 설정 추가](https://github.com/project-porko/porko-service/commit/33a9b07a9360400ad5e86f8f6b6811bbccd22eee)