### PR TITLE
config: 공통 설정 부 모듈화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,4 +221,10 @@ gradle-app.setting
 # Java heap dump
 *.hprof
 
+### fixture-monkey
+.jqwik-database
+
+### intellij qodana plugin
+qodana.yaml
+
 # End of https://www.toptal.com/developers/gitignore/api/java,gradle,intellij+all,windows,macos,visualstudiocode

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,6 +39,7 @@ subprojects {
         compileOnly("org.projectlombok:lombok")
 
         testImplementation("org.springframework.boot:spring-boot-starter-test")
+        testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter:1.0.14")
     }
 }
 

--- a/porko-common/build.gradle.kts
+++ b/porko-common/build.gradle.kts
@@ -1,0 +1,16 @@
+val bootJar: org.springframework.boot.gradle.tasks.bundling.BootJar by tasks
+
+bootJar.enabled = false
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0")
+    implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("org.springframework.boot:spring-boot-starter-web")
+
+    testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter:1.0.14")
+}

--- a/porko-common/src/main/java/io/porko/PorkoCommonConfig.java
+++ b/porko-common/src/main/java/io/porko/PorkoCommonConfig.java
@@ -1,0 +1,9 @@
+package io.porko;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+
+@ComponentScan
+@EnableAutoConfiguration
+public abstract class PorkoCommonConfig {
+}

--- a/porko-common/src/main/java/io/porko/config/jpa/JpaConfig.java
+++ b/porko-common/src/main/java/io/porko/config/jpa/JpaConfig.java
@@ -1,0 +1,9 @@
+package io.porko.config.jpa;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing(modifyOnCreate = false)
+public class JpaConfig {
+}

--- a/porko-common/src/main/java/io/porko/config/jpa/auditor/MetaFields.java
+++ b/porko-common/src/main/java/io/porko/config/jpa/auditor/MetaFields.java
@@ -1,0 +1,18 @@
+package io.porko.config.jpa.auditor;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+
+@Getter
+@MappedSuperclass
+public abstract class MetaFields extends TimeMetaFields {
+    @Column(updatable = false)
+    @CreatedBy
+    private Long createdBy;
+
+    @LastModifiedBy
+    private Long updatedBy;
+}

--- a/porko-common/src/main/java/io/porko/config/jpa/auditor/TimeMetaFields.java
+++ b/porko-common/src/main/java/io/porko/config/jpa/auditor/TimeMetaFields.java
@@ -1,0 +1,24 @@
+package io.porko.config.jpa.auditor;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@Embeddable
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class TimeMetaFields {
+    @Column(nullable = false, updatable = false)
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/porko-common/src/main/java/io/porko/config/security/PasswordEncoderConfig.java
+++ b/porko-common/src/main/java/io/porko/config/security/PasswordEncoderConfig.java
@@ -1,0 +1,14 @@
+package io.porko.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+    @Bean
+    public PasswordEncoder delegatePasswordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+}

--- a/porko-common/src/main/java/io/porko/config/security/SecurityConfig.java
+++ b/porko-common/src/main/java/io/porko/config/security/SecurityConfig.java
@@ -1,0 +1,32 @@
+package io.porko.config.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+            .formLogin(AbstractHttpConfigurer::disable)
+            .httpBasic(AbstractHttpConfigurer::disable)
+            .csrf(AbstractHttpConfigurer::disable)
+            .headers(headersConfigurer -> headersConfigurer
+                .frameOptions(FrameOptionsConfig::disable)
+            )
+            .sessionManagement(sessionManagementConfigurer -> sessionManagementConfigurer
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            )
+            .authorizeHttpRequests(auth -> auth
+                .anyRequest().permitAll()
+            )
+            .build();
+    }
+}

--- a/porko-common/src/main/java/io/porko/exception/BusinessException.java
+++ b/porko-common/src/main/java/io/porko/exception/BusinessException.java
@@ -1,0 +1,17 @@
+package io.porko.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public abstract class BusinessException extends RuntimeException {
+    protected HttpStatus status;
+    private final String code;
+    private final String message;
+
+    public BusinessException(HttpStatus status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/porko-common/src/main/java/io/porko/exception/handler/BaseExceptionHandler.java
+++ b/porko-common/src/main/java/io/porko/exception/handler/BaseExceptionHandler.java
@@ -1,0 +1,65 @@
+package io.porko.exception.handler;
+
+import io.porko.exception.BusinessException;
+import io.porko.exception.response.ErrorCode;
+import io.porko.exception.response.ErrorResponse;
+import io.porko.exception.response.invalid.MethodArgumentNotValidErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpMediaTypeNotAcceptableException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingPathVariableException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@RestControllerAdvice
+public class BaseExceptionHandler {
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> businessException(
+        BusinessException exception,
+        HttpServletRequest request
+    ) {
+        return ResponseEntity.status(exception.getStatus())
+            .body(ErrorResponse.businessErrorOf(
+                request,
+                exception
+            ));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> methodArgumentNotValidException(
+        MethodArgumentNotValidException exception,
+        HttpServletRequest request
+    ) {
+        return ResponseEntity.badRequest()
+            .body(MethodArgumentNotValidErrorResponse.of(
+                request,
+                ErrorCode.METHOD_ARGUMENT_NOT_VALID,
+                exception.getFieldErrors()
+            ));
+    }
+
+    @ExceptionHandler({
+        HttpMessageNotReadableException.class,
+        MethodArgumentTypeMismatchException.class,
+        HttpRequestMethodNotSupportedException.class,
+        HttpMediaTypeNotAcceptableException.class,
+        HttpMediaTypeNotSupportedException.class,
+        MissingPathVariableException.class,
+        MissingServletRequestParameterException.class
+    })
+    public ResponseEntity<ErrorResponse> invalidRequestException(Exception exception, HttpServletRequest request) {
+        ErrorCode errorCode = ErrorCode.valueOf(exception);
+        return ResponseEntity
+            .status(errorCode.status)
+            .body(ErrorResponse.of(
+                request,
+                errorCode)
+            );
+    }
+}

--- a/porko-common/src/main/java/io/porko/exception/handler/UnexpectedExceptionHandler.java
+++ b/porko-common/src/main/java/io/porko/exception/handler/UnexpectedExceptionHandler.java
@@ -1,0 +1,17 @@
+package io.porko.exception.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class UnexpectedExceptionHandler {
+    // TODO: 예상하지 못한 예외 발생 시, 알림 발생 이벤트 발행 및 printStackTrace() 제거
+    @ExceptionHandler({Exception.class, RuntimeException.class})
+    public ResponseEntity<?> unexpectedException(Exception exception, HttpServletRequest request) {
+        exception.printStackTrace();
+        return ResponseEntity.internalServerError()
+            .body(null);
+    }
+}

--- a/porko-common/src/main/java/io/porko/exception/response/ErrorCode.java
+++ b/porko-common/src/main/java/io/porko/exception/response/ErrorCode.java
@@ -1,5 +1,6 @@
 package io.porko.exception.response;
 
+import static io.porko.utils.ConvertUtils.convertToConstants;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.UNSUPPORTED_MEDIA_TYPE;
@@ -45,12 +46,7 @@ public enum ErrorCode {
     }
 
     private static String convertToErrorCodeName(String className) {
-        String regex = "([a-z])([A-Z])";
-        String replacement = "$1_$2";
         String exceptKeyword = "_Exception";
-
-        return className.replaceAll(regex, replacement)
-            .replace(exceptKeyword, "")
-            .toUpperCase();
+        return convertToConstants(className).replace(exceptKeyword, "");
     }
 }

--- a/porko-common/src/main/java/io/porko/exception/response/ErrorCode.java
+++ b/porko-common/src/main/java/io/porko/exception/response/ErrorCode.java
@@ -1,0 +1,56 @@
+package io.porko.exception.response;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.UNSUPPORTED_MEDIA_TYPE;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+    HTTP_MESSAGE_NOT_READABLE(BAD_REQUEST, "요청 값을 확인 할 수 없습니다. 요청 값을 확인해 주세요."),
+    METHOD_ARGUMENT_TYPE_MISMATCH(BAD_REQUEST, "요청 값의 자료형이 잘못되었습니다. 요청 값을 확인해 주세요."),
+    METHOD_ARGUMENT_NOT_VALID(BAD_REQUEST, "잘못된 요청입니다. 요청 값을 확인해 주세요."),
+    MISSING_SERVLET_REQUEST_PARAMETER(BAD_REQUEST, "잘못된 요청입니다. 요청 값을 확인해 주세요."),
+    MISSING_SERVLET_PATH_VARIABLE(BAD_REQUEST, "잘못된 요청입니다. 요청 값을 확인해 주세요."),
+    HTTP_MEDIA_TYPE_NOT_SUPPORTED(UNSUPPORTED_MEDIA_TYPE, "지원하지 않는 Media Type입니다."),
+
+    UNEXPECTED_ERROR(INTERNAL_SERVER_ERROR, "알 수 없는 오류가 발생하였습니다.");
+
+    public final HttpStatus status;
+    public final String message;
+
+    ErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public static ErrorCode valueOf(Exception exception) {
+        String errorCodeName = convertExceptionClassNameToErrorCodeName(exception);
+        try {
+            return valueOf(errorCodeName);
+        } catch (IllegalArgumentException e) {
+            return ErrorCode.UNEXPECTED_ERROR;
+        }
+    }
+
+    private static String convertExceptionClassNameToErrorCodeName(Exception exception) {
+        String className = extractExceptionClassName(exception);
+        return convertToErrorCodeName(className);
+    }
+
+    private static String extractExceptionClassName(Exception exception) {
+        return exception.getClass().getSimpleName();
+    }
+
+    private static String convertToErrorCodeName(String className) {
+        String regex = "([a-z])([A-Z])";
+        String replacement = "$1_$2";
+        String exceptKeyword = "_Exception";
+
+        return className.replaceAll(regex, replacement)
+            .replace(exceptKeyword, "")
+            .toUpperCase();
+    }
+}

--- a/porko-common/src/main/java/io/porko/exception/response/ErrorResponse.java
+++ b/porko-common/src/main/java/io/porko/exception/response/ErrorResponse.java
@@ -1,0 +1,42 @@
+package io.porko.exception.response;
+
+import io.porko.exception.BusinessException;
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
+
+@Getter
+public class ErrorResponse {
+    private final String method;
+    private final String path;
+    private final String code;
+    private final String message;
+
+    @DateTimeFormat(iso = ISO.DATE_TIME)
+    private final LocalDateTime timestamp = LocalDateTime.now();
+
+    private ErrorResponse(HttpServletRequest request, String code, String message) {
+        this.method = request.getMethod();
+        this.path = request.getRequestURI();
+        this.code = code;
+        this.message = message;
+    }
+
+    protected ErrorResponse(HttpServletRequest request, ErrorCode errorCode) {
+        this(request, errorCode.name(), errorCode.message);
+    }
+
+    private ErrorResponse(HttpServletRequest request, BusinessException exception) {
+        this(request, exception.getCode(), exception.getMessage());
+    }
+
+    public static ErrorResponse businessErrorOf(HttpServletRequest request, BusinessException exception) {
+        return new ErrorResponse(request, exception);
+    }
+
+    public static ErrorResponse of(HttpServletRequest request, ErrorCode errorCode) {
+        return new ErrorResponse(request, errorCode);
+    }
+}

--- a/porko-common/src/main/java/io/porko/exception/response/invalid/ErrorDetail.java
+++ b/porko-common/src/main/java/io/porko/exception/response/invalid/ErrorDetail.java
@@ -1,0 +1,13 @@
+package io.porko.exception.response.invalid;
+
+public record ErrorDetail(
+    String object,
+    String field,
+    String code,
+    String RejectValue,
+    Object rejectMessage
+) {
+    public static ErrorDetail of(String object, String field, String code, String RejectValue, Object rejectMessage) {
+        return new ErrorDetail(object, field, code, RejectValue, rejectMessage);
+    }
+}

--- a/porko-common/src/main/java/io/porko/exception/response/invalid/ErrorDetails.java
+++ b/porko-common/src/main/java/io/porko/exception/response/invalid/ErrorDetails.java
@@ -1,0 +1,23 @@
+package io.porko.exception.response.invalid;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.validation.FieldError;
+
+public record ErrorDetails(
+    List<ErrorDetail> elements
+) {
+    public static ErrorDetails from(List<FieldError> fieldErrors) {
+        return new ErrorDetails(
+            fieldErrors.stream()
+                .map(fieldError -> ErrorDetail.of(
+                    fieldError.getObjectName(),
+                    fieldError.getField(),
+                    fieldError.getCode(),
+                    fieldError.getDefaultMessage(),
+                    fieldError.getRejectedValue()
+                ))
+                .collect(Collectors.toList())
+        );
+    }
+}

--- a/porko-common/src/main/java/io/porko/exception/response/invalid/MethodArgumentNotValidErrorResponse.java
+++ b/porko-common/src/main/java/io/porko/exception/response/invalid/MethodArgumentNotValidErrorResponse.java
@@ -1,0 +1,34 @@
+package io.porko.exception.response.invalid;
+
+import io.porko.exception.response.ErrorCode;
+import io.porko.exception.response.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import lombok.Getter;
+import org.springframework.validation.FieldError;
+
+@Getter
+public class MethodArgumentNotValidErrorResponse extends ErrorResponse {
+    private final ErrorDetails errorDetails;
+
+    private MethodArgumentNotValidErrorResponse(
+        HttpServletRequest request,
+        ErrorCode errorCode,
+        ErrorDetails errorDetails
+    ) {
+        super(request, errorCode);
+        this.errorDetails = errorDetails;
+    }
+
+    public static MethodArgumentNotValidErrorResponse of(
+        HttpServletRequest request,
+        ErrorCode basicErrorCode,
+        List<FieldError> fieldErrors
+    ) {
+        return new MethodArgumentNotValidErrorResponse(
+            request,
+            basicErrorCode,
+            ErrorDetails.from(fieldErrors)
+        );
+    }
+}

--- a/porko-common/src/main/java/io/porko/utils/ConvertUtils.java
+++ b/porko-common/src/main/java/io/porko/utils/ConvertUtils.java
@@ -1,0 +1,36 @@
+package io.porko.utils;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class ConvertUtils {
+    public static String convertToConstants(String value) {
+        String regex = "([a-z])([A-Z])";
+        String replacement = "$1_$2";
+
+        return value.replaceAll(regex, replacement)
+            .toUpperCase();
+    }
+
+    public static Map<String, Object> convertToMap(Object obj) {
+        try {
+            if (Objects.isNull(obj)) {
+                return Collections.emptyMap();
+            }
+            Map<String, Object> convertMap = new HashMap<>();
+
+            Field[] fields = obj.getClass().getDeclaredFields();
+
+            for (Field field : fields) {
+                field.setAccessible(true);
+                convertMap.put(field.getName(), field.get(obj));
+            }
+            return convertMap;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/porko-common/src/main/java/io/porko/utils/ResponseEntityUtils.java
+++ b/porko-common/src/main/java/io/porko/utils/ResponseEntityUtils.java
@@ -1,0 +1,9 @@
+package io.porko.utils;
+
+import org.springframework.http.ResponseEntity;
+
+public class ResponseEntityUtils {
+    public static ResponseEntity<Void> created(String uriFormat, Object path) {
+        return ResponseEntity.created(UriComponentUtils.makeUrl(uriFormat, path)).build();
+    }
+}

--- a/porko-common/src/main/java/io/porko/utils/UriComponentUtils.java
+++ b/porko-common/src/main/java/io/porko/utils/UriComponentUtils.java
@@ -1,0 +1,12 @@
+package io.porko.utils;
+
+import java.net.URI;
+import org.springframework.web.util.UriComponentsBuilder;
+
+public class UriComponentUtils {
+    public static <T> URI makeUrl(String baseUri, T path) {
+        return UriComponentsBuilder.fromUriString(baseUri)
+            .buildAndExpand(path)
+            .toUri();
+    }
+}

--- a/porko-common/src/main/resources/application.yml
+++ b/porko-common/src/main/resources/application.yml
@@ -1,0 +1,8 @@
+spring:
+  config:
+    import:
+      - classpath:properties/datasource.yml
+      - classpath:properties/jpa.yml
+  profiles:
+    group:
+      test: h2-test, jpa-test

--- a/porko-common/src/main/resources/properties/datasource.yml
+++ b/porko-common/src/main/resources/properties/datasource.yml
@@ -1,0 +1,18 @@
+spring:
+  datasource:
+    hikari:
+      maximum-pool-size: 10
+      max-lifetime: 30000
+      connection-timeout: 3000
+---
+spring:
+  config.activate.on-profile: h2-test
+  datasource:
+    platform: mysql
+    hikari:
+      jdbc-url: jdbc:h2:mem:test_db;MODE=MySql
+    username: sa
+    password:
+  test.database.replace: none
+  sql.init.mode: never
+---

--- a/porko-common/src/main/resources/properties/jpa.yml
+++ b/porko-common/src/main/resources/properties/jpa.yml
@@ -1,0 +1,15 @@
+spring:
+  jpa:
+    open-in-view: false
+    properties:
+      hibernate:
+        default_batch_fetch_size: 1000
+---
+spring:
+  config.activate.on-profile: jpa-test
+  jpa:
+    database: mysql
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    defer-datasource-initialization: true
+    hibernate:
+      ddl-auto: create-drop

--- a/porko-common/src/test/java/io/porko/config/base/TestBase.java
+++ b/porko-common/src/test/java/io/porko/config/base/TestBase.java
@@ -1,0 +1,13 @@
+package io.porko.config.base;
+
+import static io.porko.config.base.TestBase.TEST;
+
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.test.context.TestConstructor.AutowireMode;
+
+@ActiveProfiles(TEST)
+@TestConstructor(autowireMode = AutowireMode.ALL)
+public abstract class TestBase {
+    static final String TEST = "test";
+}

--- a/porko-common/src/test/java/io/porko/config/base/business/ServiceTestBase.java
+++ b/porko-common/src/test/java/io/porko/config/base/business/ServiceTestBase.java
@@ -1,0 +1,9 @@
+package io.porko.config.base.business;
+
+import io.porko.config.base.TestBase;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public abstract class ServiceTestBase extends TestBase {
+}

--- a/porko-common/src/test/java/io/porko/config/base/persistence/DatasourceTestConfig.java
+++ b/porko-common/src/test/java/io/porko/config/base/persistence/DatasourceTestConfig.java
@@ -1,0 +1,16 @@
+package io.porko.config.base.persistence;
+
+import com.github.gavlyukovskiy.boot.jdbc.decorator.DataSourceDecoratorAutoConfiguration;
+import io.porko.config.base.TestBase;
+import io.porko.config.jpa.TestJpaConfiguration;
+import io.porko.config.p6spy.P6spySqlFormatConfiguration;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.context.annotation.Import;
+
+@Import({
+    TestJpaConfiguration.class,
+    P6spySqlFormatConfiguration.class
+})
+@ImportAutoConfiguration(DataSourceDecoratorAutoConfiguration.class)
+public abstract class DatasourceTestConfig extends TestBase {
+}

--- a/porko-common/src/test/java/io/porko/config/base/persistence/JpaTestBase.java
+++ b/porko-common/src/test/java/io/porko/config/base/persistence/JpaTestBase.java
@@ -1,0 +1,7 @@
+package io.porko.config.base.persistence;
+
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest(showSql = false)
+public abstract class JpaTestBase extends DatasourceTestConfig {
+}

--- a/porko-common/src/test/java/io/porko/config/base/presentation/RequestBuilder.java
+++ b/porko-common/src/test/java/io/porko/config/base/presentation/RequestBuilder.java
@@ -1,0 +1,197 @@
+package io.porko.config.base.presentation;
+
+import static org.springframework.http.HttpMethod.DELETE;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpMethod.PUT;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+public class RequestBuilder {
+    private final MockMvc mockMvc;
+
+    private final ObjectMapper objectMapper;
+
+    private String url;
+
+    private List<Object> urlVariables;
+
+    private HttpMethod method;
+
+    private final Map<String, Object> headers = new HashMap<>();
+    private MediaType contentType;
+
+    private Object content;
+
+    private HttpStatus status;
+
+    private RequestBuilder(final MockMvc mockMvc, final ObjectMapper mapper) {
+        this.mockMvc = mockMvc;
+        this.objectMapper = mapper;
+        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+    }
+
+    public static EndPoint get(final MockMvc mockMvc, final ObjectMapper objectMapper) {
+        return new RequestBuilder(mockMvc, objectMapper)
+            .request()
+            .get();
+    }
+
+    public static EndPoint post(final MockMvc mockMvc, final ObjectMapper objectMapper) {
+        return new RequestBuilder(mockMvc, objectMapper)
+            .request()
+            .post();
+    }
+
+    public static EndPoint put(final MockMvc mockMvc, final ObjectMapper objectMapper) {
+        return new RequestBuilder(mockMvc, objectMapper)
+            .request()
+            .put();
+    }
+
+    public static EndPoint delete(final MockMvc mockMvc, final ObjectMapper objectMapper) {
+        return new RequestBuilder(mockMvc, objectMapper)
+            .request()
+            .delete();
+    }
+
+    private Method request() {
+        return new Method();
+    }
+
+    public class Method {
+        public EndPoint method(final HttpMethod methodInput) {
+            method = methodInput;
+            return new EndPoint();
+        }
+
+        public EndPoint get() {
+            method = GET;
+            return new EndPoint();
+        }
+
+        public EndPoint post() {
+            method = POST;
+            return new EndPoint();
+        }
+
+        public EndPoint put() {
+            method = PUT;
+            return new EndPoint();
+        }
+
+        public EndPoint delete() {
+            method = DELETE;
+            return new EndPoint();
+        }
+    }
+
+    public class EndPoint {
+        public Content url(final String urlInput, final Object... urlVariablesInput) {
+            url = urlInput;
+            urlVariables = Arrays.asList(urlVariablesInput);
+            return new Content();
+        }
+    }
+
+    public class Content {
+        public Expect jsonContent(final Object object) {
+            contentType = MediaType.APPLICATION_JSON;
+            content = object;
+            return new Expect();
+        }
+
+        public Expect expect() {
+            return new Expect();
+        }
+    }
+
+    public class Expect {
+        public ResultActions expectStatus(HttpStatus expectStatus) throws Exception {
+            status = expectStatus;
+            return makeRequest();
+        }
+
+        public ResultActions ok() throws Exception {
+            status = HttpStatus.OK;
+            return makeRequest();
+        }
+
+        public ResultActions noContent() throws Exception {
+            status = HttpStatus.NO_CONTENT;
+            return makeRequest();
+        }
+
+        public ResultActions created() throws Exception {
+            status = HttpStatus.CREATED;
+            return makeRequest();
+        }
+
+        public ResultActions unAuthorized() throws Exception {
+            status = HttpStatus.UNAUTHORIZED;
+            return makeRequest();
+        }
+
+        public ResultActions forbidden() throws Exception {
+            status = HttpStatus.FORBIDDEN;
+            return makeRequest();
+        }
+
+        public ResultActions badRequest() throws Exception {
+            status = HttpStatus.BAD_REQUEST;
+            return makeRequest();
+        }
+
+        public ResultActions notFound() throws Exception {
+            status = HttpStatus.NOT_FOUND;
+            return makeRequest();
+        }
+
+        public ResultActions conflict() throws Exception {
+            status = HttpStatus.CONFLICT;
+            return makeRequest();
+        }
+    }
+
+    /**
+     * TODO : TC 기반 API docs 추출 시 RequestBuilder 변경
+     * - as-is :MockMvcRequestBuilders
+     * - to-be : RestDocumentationRequestBuilders
+     */
+    private ResultActions makeRequest() throws Exception {
+        MockHttpServletRequestBuilder request =
+            MockMvcRequestBuilders.request(
+                method,
+                url,
+                urlVariables.toArray()
+            );
+
+        for (String header : headers.keySet()) {
+            request.header(header, headers.get(header));
+        }
+
+        if (content != null) {
+            request.contentType(contentType)
+                .content(objectMapper.writeValueAsString(content));
+        }
+
+        return mockMvc.perform(request)
+            .andDo(print())
+            .andExpect(status().is(status.value()));
+    }
+}

--- a/porko-common/src/test/java/io/porko/config/base/presentation/RequestBuilder.java
+++ b/porko-common/src/test/java/io/porko/config/base/presentation/RequestBuilder.java
@@ -33,8 +33,10 @@ public class RequestBuilder {
 
     private HttpMethod method;
 
-    private final Map<String, Object> headers = new HashMap<>();
-    private MediaType contentType;
+    private final Map<String, Object> headers = new HashMap<>() {{
+        put("Content-Type", MediaType.APPLICATION_JSON);
+        put("Accept", MediaType.APPLICATION_JSON);
+    }};
 
     private Object content;
 
@@ -111,7 +113,6 @@ public class RequestBuilder {
 
     public class Content {
         public Expect jsonContent(final Object object) {
-            contentType = MediaType.APPLICATION_JSON;
             content = object;
             return new Expect();
         }
@@ -181,13 +182,12 @@ public class RequestBuilder {
                 urlVariables.toArray()
             );
 
-        for (String header : headers.keySet()) {
-            request.header(header, headers.get(header));
+        for (String key : headers.keySet()) {
+            request.header(key, headers.get(key));
         }
 
         if (content != null) {
-            request.contentType(contentType)
-                .content(objectMapper.writeValueAsString(content));
+            request.content(objectMapper.writeValueAsString(content));
         }
 
         return mockMvc.perform(request)

--- a/porko-common/src/test/java/io/porko/config/base/presentation/WebMvcTestBase.java
+++ b/porko-common/src/test/java/io/porko/config/base/presentation/WebMvcTestBase.java
@@ -1,0 +1,44 @@
+package io.porko.config.base.presentation;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.porko.config.base.TestBase;
+import io.porko.config.security.TestSecurityConfig;
+import jakarta.annotation.Resource;
+import java.io.UnsupportedEncodingException;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@Import(TestSecurityConfig.class)
+public abstract class WebMvcTestBase extends TestBase {
+    @Resource
+    protected MockMvc mockMvc;
+    @Resource
+    protected ObjectMapper objectMapper;
+
+    protected RequestBuilder.EndPoint get() {
+        return RequestBuilder.get(mockMvc, objectMapper);
+    }
+
+    protected RequestBuilder.EndPoint post() {
+        return RequestBuilder.post(mockMvc, objectMapper);
+    }
+
+    protected RequestBuilder.EndPoint put() {
+        return RequestBuilder.put(mockMvc, objectMapper);
+    }
+
+    protected RequestBuilder.EndPoint delete() {
+        return RequestBuilder.delete(mockMvc, objectMapper);
+    }
+
+    protected <T> T andReturn(ResultActions resultActions, Class<T> clazz)
+        throws UnsupportedEncodingException, JsonProcessingException {
+        return objectMapper.readValue(extractResponseBody(resultActions), clazz);
+    }
+
+    private String extractResponseBody(ResultActions resultActions) throws UnsupportedEncodingException {
+        return resultActions.andReturn().getResponse().getContentAsString();
+    }
+}

--- a/porko-common/src/test/java/io/porko/config/fixture/FixtureCommon.java
+++ b/porko-common/src/test/java/io/porko/config/fixture/FixtureCommon.java
@@ -6,6 +6,8 @@ import com.navercorp.fixturemonkey.api.introspector.BuilderArbitraryIntrospector
 import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
 import com.navercorp.fixturemonkey.jakarta.validation.plugin.JakartaValidationPlugin;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.arbitraries.StringArbitrary;
 
 public class FixtureCommon {
     private static final FixtureMonkeyBuilder builder = FixtureMonkey.builder();
@@ -36,5 +38,9 @@ public class FixtureCommon {
         return builder
             .objectIntrospector(BuilderArbitraryIntrospector.INSTANCE)
             .build();
+    }
+
+    public static StringArbitrary randomString() {
+        return Arbitraries.strings();
     }
 }

--- a/porko-common/src/test/java/io/porko/config/fixture/FixtureCommon.java
+++ b/porko-common/src/test/java/io/porko/config/fixture/FixtureCommon.java
@@ -1,0 +1,40 @@
+package io.porko.config.fixture;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.FixtureMonkeyBuilder;
+import com.navercorp.fixturemonkey.api.introspector.BuilderArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
+import com.navercorp.fixturemonkey.jakarta.validation.plugin.JakartaValidationPlugin;
+
+public class FixtureCommon {
+    private static final FixtureMonkeyBuilder builder = FixtureMonkey.builder();
+
+    public static FixtureMonkey entityType() {
+        return builder
+            .objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
+            .defaultNotNull(true)
+            .build();
+    }
+
+    public static FixtureMonkey dtoType() {
+        return builder
+            .objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
+            .defaultNotNull(true)
+            .build();
+    }
+
+    public static FixtureMonkey withValidated() {
+        return builder
+            .objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
+            .defaultNotNull(true)
+            .plugin(new JakartaValidationPlugin())
+            .build();
+    }
+
+    public static FixtureMonkey builderType() {
+        return builder
+            .objectIntrospector(BuilderArbitraryIntrospector.INSTANCE)
+            .build();
+    }
+}

--- a/porko-common/src/test/java/io/porko/config/jpa/TestJpaConfiguration.java
+++ b/porko-common/src/test/java/io/porko/config/jpa/TestJpaConfiguration.java
@@ -1,0 +1,10 @@
+package io.porko.config.jpa;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+// TODO: Test 환경에서 사용할 사용자 정보를 통해 AuditingListener가 설정할 메타 데이터 제공
+@TestConfiguration
+@EnableJpaAuditing(modifyOnCreate = false)
+public class TestJpaConfiguration {
+}

--- a/porko-common/src/test/java/io/porko/config/p6spy/P6spySqlFormatConfiguration.java
+++ b/porko-common/src/test/java/io/porko/config/p6spy/P6spySqlFormatConfiguration.java
@@ -1,0 +1,87 @@
+package io.porko.config.p6spy;
+
+import com.p6spy.engine.common.ConnectionInformation;
+import com.p6spy.engine.event.JdbcEventListener;
+import com.p6spy.engine.logging.Category;
+import com.p6spy.engine.spy.P6SpyOptions;
+import com.p6spy.engine.spy.appender.MessageFormattingStrategy;
+import java.sql.SQLException;
+import java.util.Locale;
+import org.hibernate.engine.jdbc.internal.FormatStyle;
+import org.hibernate.engine.jdbc.internal.Formatter;
+import org.springframework.boot.test.context.TestComponent;
+
+@TestComponent
+public class P6spySqlFormatConfiguration extends JdbcEventListener implements MessageFormattingStrategy {
+    public static final String CREATE = "create";
+    public static final String ALTER = "alter";
+    public static final String COMMENT = "comment";
+    public static final String EXECUTE_QUERY_LOG_FORMAT = "\n[Connection : %s][%s][%d ms] %s";
+
+    @Override
+    public void onAfterGetConnection(ConnectionInformation connectionInformation, SQLException e) {
+        P6SpyOptions.getActiveInstance().setLogMessageFormat(getClass().getName());
+    }
+
+    @Override
+    public String formatMessage(
+        int connectionId,
+        String now,
+        long duration,
+        String category,
+        String prepared,
+        String sql,
+        String url
+    ) {
+        return String.format(
+            EXECUTE_QUERY_LOG_FORMAT,
+            connectionId,
+            category,
+            duration,
+            formatSql(category, sql)
+        );
+    }
+
+    private String formatSql(String category, String sql) {
+        if (isNotStatementCategory(category)) {
+            return sql;
+        }
+        return formatSqlByStatementCategory(sql);
+    }
+
+    private boolean isNotStatementCategory(String category) {
+        return !isStatementCategory(category);
+    }
+
+    private boolean isStatementCategory(String category) {
+        return Category.STATEMENT.getName().equals(category);
+    }
+
+    private String formatSqlByStatementCategory(String sql) {
+        if (isDataDefinitionLanguage(sql)) {
+            return toFormat(FormatStyle.DDL, sql);
+        }
+        return applyHighlighter(toFormat(FormatStyle.BASIC, sql));
+    }
+
+    private boolean isDataDefinitionLanguage(String sql) {
+        String statement = toLowerCase(sql);
+        return statement.startsWith(CREATE) || statement.startsWith(ALTER) || statement.startsWith(COMMENT);
+    }
+
+    private String toLowerCase(String sql) {
+        return sql.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private String toFormat(FormatStyle formatStyle, String sql) {
+        return getFormatter(formatStyle).format(sql);
+    }
+
+    private Formatter getFormatter(FormatStyle formatStyle) {
+        return formatStyle.getFormatter();
+    }
+
+    private String applyHighlighter(String sql) {
+        return FormatStyle.HIGHLIGHT.getFormatter().format(sql);
+    }
+}

--- a/porko-common/src/test/java/io/porko/config/security/TestSecurityConfig.java
+++ b/porko-common/src/test/java/io/porko/config/security/TestSecurityConfig.java
@@ -1,0 +1,8 @@
+package io.porko.config.security;
+
+import org.springframework.context.annotation.Import;
+
+// TODO: Mocking을 통해 인증된 사용자 정보 제공
+@Import(SecurityConfig.class)
+public class TestSecurityConfig {
+}

--- a/porko-service/build.gradle.kts
+++ b/porko-service/build.gradle.kts
@@ -1,0 +1,12 @@
+val testSourceSet: SourceSetOutput = project(":porko-common").sourceSets["test"].output
+
+dependencies {
+    implementation(project(":porko-common"))
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+
+    testRuntimeOnly("com.h2database:h2")
+    testImplementation(testSourceSet)
+}

--- a/porko-service/src/main/java/io/porko/PorkoServiceApp.java
+++ b/porko-service/src/main/java/io/porko/PorkoServiceApp.java
@@ -1,0 +1,12 @@
+package io.porko;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class PorkoServiceApp {
+    public static void main(String[] args) {
+        System.setProperty("spring.config.name", "application, application-service");
+        SpringApplication.run(PorkoServiceApp.class, args);
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/controller/MemberController.java
+++ b/porko-service/src/main/java/io/porko/member/controller/MemberController.java
@@ -1,0 +1,55 @@
+package io.porko.member.controller;
+
+import static io.porko.member.controller.MemberController.MEMBER_BASE_URI;
+
+import io.porko.member.controller.model.SignUpRequest;
+import io.porko.member.controller.model.ValidateDuplicateRequest;
+import io.porko.member.controller.model.ValidateDuplicateResponse;
+import io.porko.member.facade.ValidateDuplicateFacade;
+import io.porko.member.service.MemberService;
+import io.porko.utils.ResponseEntityUtils;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping(
+    value = MEMBER_BASE_URI,
+    consumes = MediaType.APPLICATION_JSON_VALUE,
+    produces = MediaType.APPLICATION_JSON_VALUE
+)
+@RestController
+@RequiredArgsConstructor
+public class MemberController {
+    static final String MEMBER_BASE_URI = "/member";
+    private static final String GET_AN_MEMBER_URI_FORMAT = MEMBER_BASE_URI.concat("/{id}");
+
+    private final ValidateDuplicateFacade validateDuplicateFacade;
+    private final MemberService memberService;
+
+    @GetMapping("validate")
+    ResponseEntity<ValidateDuplicateResponse> validateDuplicate(
+        @RequestParam(name = "memberId", required = false) String memberId,
+        @RequestParam(name = "email", required = false) String email
+    ) {
+        System.out.println(memberId);
+        ValidateDuplicateResponse duplicated = validateDuplicateFacade.isDuplicated(
+            ValidateDuplicateRequest.of(memberId, email)
+        );
+        return ResponseEntity.ok(duplicated);
+    }
+
+    @PostMapping("sign-up")
+    ResponseEntity<Void> signUp(@Valid @RequestBody SignUpRequest signUpRequest) {
+        return ResponseEntityUtils.created(
+            GET_AN_MEMBER_URI_FORMAT,
+            memberService.createMember(signUpRequest)
+        );
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/controller/model/AddressDto.java
+++ b/porko-service/src/main/java/io/porko/member/controller/model/AddressDto.java
@@ -1,0 +1,12 @@
+package io.porko.member.controller.model;
+
+import io.porko.member.domain.Address;
+
+public record AddressDto(
+    String roadName,
+    String detail
+) {
+    public Address toEntity() {
+        return Address.of(roadName, detail);
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/controller/model/AvailabilityStatus.java
+++ b/porko-service/src/main/java/io/porko/member/controller/model/AvailabilityStatus.java
@@ -1,0 +1,12 @@
+package io.porko.member.controller.model;
+
+public enum AvailabilityStatus {
+    AVAILABLE, UNAVAILABLE;
+
+    public static AvailabilityStatus valueOf(boolean isDuplicated) {
+        if (isDuplicated) {
+            return UNAVAILABLE;
+        }
+        return AVAILABLE;
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/controller/model/SignUpRequest.java
+++ b/porko-service/src/main/java/io/porko/member/controller/model/SignUpRequest.java
@@ -1,0 +1,47 @@
+package io.porko.member.controller.model;
+
+import io.porko.member.domain.Gender;
+import io.porko.member.domain.Member;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record SignUpRequest(
+    @NotBlank
+    @Size(min = 6, max = 20)
+    String memberId,
+
+    @NotBlank
+    String password,
+
+    @NotBlank
+    @Size(max = 10)
+    String name,
+
+    @NotBlank
+    @Size(max = 40)
+    @Email
+    String email,
+
+    @NotBlank
+    @Size(max = 11)
+    String phoneNumber,
+
+    AddressDto address,
+
+    @NotNull
+    Gender gender
+) {
+    public Member toEntity(String encodedPassword) {
+        return Member.of(
+            memberId,
+            encodedPassword,
+            name,
+            email,
+            phoneNumber,
+            address.toEntity(),
+            gender
+        );
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/controller/model/ValidateDuplicateRequest.java
+++ b/porko-service/src/main/java/io/porko/member/controller/model/ValidateDuplicateRequest.java
@@ -1,0 +1,10 @@
+package io.porko.member.controller.model;
+
+public record ValidateDuplicateRequest(
+    String memberId,
+    String email
+) {
+    public static ValidateDuplicateRequest of(String memberId, String email) {
+        return new ValidateDuplicateRequest(memberId, email);
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/controller/model/ValidateDuplicateResponse.java
+++ b/porko-service/src/main/java/io/porko/member/controller/model/ValidateDuplicateResponse.java
@@ -1,0 +1,20 @@
+package io.porko.member.controller.model;
+
+import io.porko.member.facade.dto.ValidateDuplicateRequestField;
+import io.porko.member.facade.dto.ValidateDuplicateRequestType;
+
+public record ValidateDuplicateResponse(
+    ValidateDuplicateRequestType requestType,
+    String requestValue,
+    boolean isDuplicated,
+    AvailabilityStatus availabilityStatus
+) {
+    public static ValidateDuplicateResponse of(ValidateDuplicateRequestField requestField, boolean isDuplicated) {
+        return new ValidateDuplicateResponse(
+            requestField.requestType(),
+            requestField.value(),
+            isDuplicated,
+            AvailabilityStatus.valueOf(isDuplicated)
+        );
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/domain/Address.java
+++ b/porko-service/src/main/java/io/porko/member/domain/Address.java
@@ -1,0 +1,27 @@
+package io.porko.member.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.AccessType;
+import org.springframework.data.annotation.AccessType.Type;
+
+@Getter
+@Embeddable
+@AccessType(Type.FIELD)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Address {
+    @Column(nullable = false)
+    private String roadName;
+    
+    @Column(nullable = false, length = 30)
+    private String detail;
+
+    public static Address of(String roadName, String detail) {
+        return new Address(roadName, detail);
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/domain/Gender.java
+++ b/porko-service/src/main/java/io/porko/member/domain/Gender.java
@@ -1,0 +1,5 @@
+package io.porko.member.domain;
+
+public enum Gender {
+    MALE, FEMALE
+}

--- a/porko-service/src/main/java/io/porko/member/domain/Member.java
+++ b/porko-service/src/main/java/io/porko/member/domain/Member.java
@@ -1,0 +1,81 @@
+package io.porko.member.domain;
+
+import io.porko.config.jpa.auditor.TimeMetaFields;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(
+    uniqueConstraints = {
+        @UniqueConstraint(name = "UK_MEMBER_ID", columnNames = "member_id"),
+        @UniqueConstraint(name = "UK_MEMBER_EMAIL", columnNames = "email")
+    })
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends TimeMetaFields {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 20)
+    private String memberId;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false, length = 10)
+    private String name;
+
+    @Column(nullable = false, length = 40)
+    private String email;
+
+    @Column(nullable = false, length = 11)
+    private String phoneNumber;
+
+    @Embedded
+    private Address address;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+    private Member(
+        String memberId,
+        String password,
+        String name,
+        String email,
+        String phoneNumber,
+        Address address,
+        Gender gender
+    ) {
+        this.memberId = memberId;
+        this.password = password;
+        this.name = name;
+        this.email = email;
+        this.phoneNumber = phoneNumber;
+        this.address = address;
+        this.gender = gender;
+    }
+
+    public static Member of(String memberId,
+        String password,
+        String name,
+        String email,
+        String phoneNumber,
+        Address address,
+        Gender gender
+    ) {
+        return new Member(memberId, password, name, email, phoneNumber, address, gender);
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/exception/MemberErrorCode.java
+++ b/porko-service/src/main/java/io/porko/member/exception/MemberErrorCode.java
@@ -1,0 +1,27 @@
+package io.porko.member.exception;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum MemberErrorCode {
+    DUPLICATED_MEMBER_ID(BAD_REQUEST, "중복된 ID입니다. [request: %s]"),
+    DUPLICATED_EMAIL(BAD_REQUEST, "중복된 이메일입니다. [request: %s]"),
+    INVALID_VALIDATE_DUPLICATE_TARGET_FORMAT(BAD_REQUEST, "중복 검사 대상 항목의 형식이 유효하지 않습니다. [request: %s]"),
+    UNSUPPORTED_VALIDATE_DUPLICATE_TARGET(BAD_REQUEST, "지원하지 않는 중복 검사 대상 항목입니다. [request: %s]"),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+
+    MemberErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public String formattingErrorMessage(Object... objects) {
+        return getMessage().formatted(objects);
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/exception/MemberException.java
+++ b/porko-service/src/main/java/io/porko/member/exception/MemberException.java
@@ -1,0 +1,16 @@
+package io.porko.member.exception;
+
+import io.porko.exception.BusinessException;
+
+public class MemberException extends BusinessException {
+    private MemberErrorCode errorCode;
+    private String message;
+
+    public MemberException(MemberErrorCode errorCode, Object... args) {
+        super(
+            errorCode.getStatus(),
+            errorCode.name(),
+            errorCode.formattingErrorMessage(args)
+        );
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/facade/ValidateDuplicateFacade.java
+++ b/porko-service/src/main/java/io/porko/member/facade/ValidateDuplicateFacade.java
@@ -1,0 +1,45 @@
+package io.porko.member.facade;
+
+import static io.porko.utils.ConvertUtils.convertToMap;
+
+import io.porko.member.controller.model.ValidateDuplicateRequest;
+import io.porko.member.controller.model.ValidateDuplicateResponse;
+import io.porko.member.exception.MemberErrorCode;
+import io.porko.member.exception.MemberException;
+import io.porko.member.facade.dto.ValidateDuplicateRequestField;
+import io.porko.member.facade.strategy.ValidateDuplicateStrategy;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ValidateDuplicateFacade {
+    private final List<ValidateDuplicateStrategy> validateDuplicateStrategies;
+
+    public ValidateDuplicateResponse isDuplicated(ValidateDuplicateRequest validateDuplicateRequest) {
+        ValidateDuplicateRequestField requestField = extractValidateDuplicateRequestField(validateDuplicateRequest);
+
+        return validateDuplicateStrategies.stream()
+            .filter(it -> it.isSupport(requestField.requestType()))
+            .findAny()
+            .orElseThrow(() -> new MemberException(MemberErrorCode.UNSUPPORTED_VALIDATE_DUPLICATE_TARGET, validateDuplicateRequest))
+            .isDuplicated(requestField)
+            ;
+    }
+
+    private ValidateDuplicateRequestField extractValidateDuplicateRequestField(ValidateDuplicateRequest validateDuplicateRequest) {
+        Map<String, Object> validateDuplicateRequestMap = convertToMap(validateDuplicateRequest);
+        return extractRequestEntry(validateDuplicateRequestMap);
+    }
+
+    private ValidateDuplicateRequestField extractRequestEntry(Map<String, Object> rquestMap) {
+        return rquestMap.entrySet().stream()
+            .filter(entry -> entry.getValue() != null)
+            .map(ValidateDuplicateRequestField::of)
+            .findAny()
+            .orElseThrow(() -> new MemberException(MemberErrorCode.INVALID_VALIDATE_DUPLICATE_TARGET_FORMAT, rquestMap))
+            ;
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/facade/dto/ValidateDuplicateRequestField.java
+++ b/porko-service/src/main/java/io/porko/member/facade/dto/ValidateDuplicateRequestField.java
@@ -1,0 +1,30 @@
+package io.porko.member.facade.dto;
+
+import static io.porko.utils.ConvertUtils.convertToConstants;
+
+import java.util.Map.Entry;
+
+public record ValidateDuplicateRequestField(
+    ValidateDuplicateRequestType requestType,
+    String value
+) {
+    public static ValidateDuplicateRequestField of(Entry<String, Object> entry) {
+        ValidateDuplicateRequestType requestType = toValidateType(entry.getKey());
+        String value = castToString(entry.getValue());
+        requestType.validateFormat(value);
+
+        return new ValidateDuplicateRequestField(
+            requestType,
+            value
+        );
+    }
+
+    private static ValidateDuplicateRequestType toValidateType(String requestField) {
+        String ValidateDuplicateRequestTypeConstants = convertToConstants(requestField);
+        return ValidateDuplicateRequestType.valueOf(ValidateDuplicateRequestTypeConstants);
+    }
+
+    public static String castToString(Object value) {
+        return (String) value;
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/facade/dto/ValidateDuplicateRequestType.java
+++ b/porko-service/src/main/java/io/porko/member/facade/dto/ValidateDuplicateRequestType.java
@@ -1,0 +1,36 @@
+package io.porko.member.facade.dto;
+
+import static java.util.regex.Pattern.compile;
+
+import io.porko.member.exception.MemberErrorCode;
+import io.porko.member.exception.MemberException;
+import java.util.regex.Pattern;
+
+public enum ValidateDuplicateRequestType {
+    MEMBER_ID(compile("^[a-zA-Z0-9]{6,20}$")),
+    EMAIL(compile("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$"));
+
+    private final Pattern pattern;
+
+    ValidateDuplicateRequestType(Pattern pattern) {
+        this.pattern = pattern;
+    }
+
+    public void validateFormat(String value) {
+        if (value == null || isNotMatched(value)) {
+            throw new MemberException(MemberErrorCode.INVALID_VALIDATE_DUPLICATE_TARGET_FORMAT, value);
+        }
+    }
+
+    private boolean isNotMatched(String value) {
+        return !pattern.matcher(value).matches();
+    }
+
+    public boolean isMemberId() {
+        return this == MEMBER_ID;
+    }
+
+    public boolean isEmail() {
+        return this == EMAIL;
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/facade/strategy/EmailDuplicateStrategy.java
+++ b/porko-service/src/main/java/io/porko/member/facade/strategy/EmailDuplicateStrategy.java
@@ -1,0 +1,27 @@
+package io.porko.member.facade.strategy;
+
+import io.porko.member.controller.model.ValidateDuplicateResponse;
+import io.porko.member.facade.dto.ValidateDuplicateRequestField;
+import io.porko.member.facade.dto.ValidateDuplicateRequestType;
+import io.porko.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EmailDuplicateStrategy implements ValidateDuplicateStrategy {
+    private final MemberService memberService;
+
+    @Override
+    public ValidateDuplicateResponse isDuplicated(ValidateDuplicateRequestField requestField) {
+        return ValidateDuplicateResponse.of(
+            requestField,
+            memberService.isDuplicatedEmail(requestField.value())
+        );
+    }
+
+    @Override
+    public boolean isSupport(ValidateDuplicateRequestType requestType) {
+        return requestType.isEmail();
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/facade/strategy/MemberIdDuplicateStrategy.java
+++ b/porko-service/src/main/java/io/porko/member/facade/strategy/MemberIdDuplicateStrategy.java
@@ -1,0 +1,27 @@
+package io.porko.member.facade.strategy;
+
+import io.porko.member.controller.model.ValidateDuplicateResponse;
+import io.porko.member.facade.dto.ValidateDuplicateRequestField;
+import io.porko.member.facade.dto.ValidateDuplicateRequestType;
+import io.porko.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberIdDuplicateStrategy implements ValidateDuplicateStrategy {
+    private final MemberService memberService;
+
+    @Override
+    public ValidateDuplicateResponse isDuplicated(ValidateDuplicateRequestField requestField) {
+        return ValidateDuplicateResponse.of(
+            requestField,
+            memberService.isDuplicatedMemberId(requestField.value())
+        );
+    }
+
+    @Override
+    public boolean isSupport(ValidateDuplicateRequestType requestType) {
+        return requestType.isMemberId();
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/facade/strategy/ValidateDuplicateStrategy.java
+++ b/porko-service/src/main/java/io/porko/member/facade/strategy/ValidateDuplicateStrategy.java
@@ -1,0 +1,11 @@
+package io.porko.member.facade.strategy;
+
+import io.porko.member.controller.model.ValidateDuplicateResponse;
+import io.porko.member.facade.dto.ValidateDuplicateRequestField;
+import io.porko.member.facade.dto.ValidateDuplicateRequestType;
+
+public interface ValidateDuplicateStrategy {
+    ValidateDuplicateResponse isDuplicated(ValidateDuplicateRequestField requestField);
+
+    boolean isSupport(ValidateDuplicateRequestType requestType);
+}

--- a/porko-service/src/main/java/io/porko/member/repo/MemberRepo.java
+++ b/porko-service/src/main/java/io/porko/member/repo/MemberRepo.java
@@ -1,0 +1,10 @@
+package io.porko.member.repo;
+
+import io.porko.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepo extends JpaRepository<Member, Long> {
+    boolean existsByEmail(String email);
+
+    boolean existsByMemberId(String memberId);
+}

--- a/porko-service/src/main/java/io/porko/member/service/MemberService.java
+++ b/porko-service/src/main/java/io/porko/member/service/MemberService.java
@@ -1,0 +1,53 @@
+package io.porko.member.service;
+
+import static io.porko.member.exception.MemberErrorCode.DUPLICATED_EMAIL;
+import static io.porko.member.exception.MemberErrorCode.DUPLICATED_MEMBER_ID;
+
+import io.porko.member.controller.model.SignUpRequest;
+import io.porko.member.exception.MemberException;
+import io.porko.member.repo.MemberRepo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepo memberRepo;
+    private final PasswordEncoder passwordEncoder;
+
+    public boolean isDuplicatedMemberId(String memberId) {
+        return memberRepo.existsByMemberId(memberId);
+    }
+
+    public boolean isDuplicatedEmail(String email) {
+        return memberRepo.existsByEmail(email);
+    }
+
+    @Transactional
+    public Long createMember(SignUpRequest signUpRequest) {
+        checkDuplicatedMemberId(signUpRequest.memberId());
+        checkDuplicatedEmail(signUpRequest.email());
+        String encryptedPassword = encryptPassword(signUpRequest.password());
+
+        return memberRepo.save(signUpRequest.toEntity(encryptedPassword)).getId();
+    }
+
+    private void checkDuplicatedMemberId(String memberId) {
+        if (isDuplicatedMemberId(memberId)) {
+            throw new MemberException(DUPLICATED_MEMBER_ID, memberId);
+        }
+    }
+
+    private void checkDuplicatedEmail(String email) {
+        if (isDuplicatedEmail(email)) {
+            throw new MemberException(DUPLICATED_EMAIL, email);
+        }
+    }
+
+    private String encryptPassword(String password) {
+        return passwordEncoder.encode(password);
+    }
+}

--- a/porko-service/src/test/java/io/porko/member/controller/MemberControllerTest.java
+++ b/porko-service/src/test/java/io/porko/member/controller/MemberControllerTest.java
@@ -1,0 +1,94 @@
+package io.porko.member.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import io.porko.config.fixture.FixtureCommon;
+import io.porko.member.controller.model.AvailabilityStatus;
+import io.porko.member.controller.model.SignUpRequest;
+import io.porko.member.controller.model.ValidateDuplicateRequest;
+import io.porko.member.controller.model.ValidateDuplicateResponse;
+import io.porko.member.facade.dto.ValidateDuplicateRequestField;
+import io.porko.member.facade.dto.ValidateDuplicateRequestType;
+import java.util.AbstractMap.SimpleEntry;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.ResultActions;
+
+@DisplayName("Controller:Member")
+class MemberControllerTest extends MemberControllerTestHelper {
+
+    @Test
+    @DisplayName("[GET:200]회원 아이디 중복 검사 : 아이디가 중복되지 않은 경우")
+    void validateMemberIdDuplicate_WhenNotDuplicatedMemberId() throws Exception {
+        // Given
+        String 중복_검사_요청_항목_명 = "memberId";
+        String 중복_검사_요청_항목 = "porkoId";
+        ValidateDuplicateRequest 중복_검사_요청_객체 = ValidateDuplicateRequest.of(중복_검사_요청_항목, null);
+        ValidateDuplicateRequestField 중목_검사_요청_항목 = ValidateDuplicateRequestField.of(new SimpleEntry<>(중복_검사_요청_항목_명, 중복_검사_요청_항목));
+
+        given(validateDuplicateFacade.isDuplicated(중복_검사_요청_객체))
+            .willReturn(ValidateDuplicateResponse.of(중목_검사_요청_항목, false));
+
+        // When
+        ResultActions 중복_검사_요청_결과 = 중복_검사_요청(중복_검사_요청_항목_명, 중복_검사_요청_항목).ok();
+
+        // Then
+        verify(validateDuplicateFacade).isDuplicated(중복_검사_요청_객체);
+
+        ValidateDuplicateResponse 중복_검사_요청_응답 = andReturn(중복_검사_요청_결과, ValidateDuplicateResponse.class);
+        assertAll(
+            () -> assertThat(중복_검사_요청_응답.requestType()).isEqualTo(ValidateDuplicateRequestType.MEMBER_ID),
+            () -> assertThat(중복_검사_요청_응답.requestValue()).isEqualTo(중복_검사_요청_항목),
+            () -> assertThat(중복_검사_요청_응답.isDuplicated()).isFalse(),
+            () -> assertThat(중복_검사_요청_응답.availabilityStatus()).isEqualTo(AvailabilityStatus.AVAILABLE)
+        );
+    }
+
+    @Test
+    @DisplayName("[GET:200]회원 아이디 중복 검사 : 아이디가 중복된 경우")
+    void validateMemberIdDuplicate_WhenDuplicatedMemberId() throws Exception {
+        // Given
+        String 중복_검사_요청_항목_명 = "memberId";
+        String 중복_검사_요청_항목 = "porkoId";
+        ValidateDuplicateRequest 중복_검사_요청_객체 = ValidateDuplicateRequest.of(중복_검사_요청_항목, null);
+        ValidateDuplicateRequestField 중목_검사_요청_항목 = ValidateDuplicateRequestField.of(new SimpleEntry<>(중복_검사_요청_항목_명, 중복_검사_요청_항목));
+
+        given(validateDuplicateFacade.isDuplicated(중복_검사_요청_객체))
+            .willReturn(ValidateDuplicateResponse.of(중목_검사_요청_항목, true));
+
+        // When
+        ResultActions 중복_검사_요청_결과 = 중복_검사_요청(중복_검사_요청_항목_명, 중복_검사_요청_항목).ok();
+
+        // Then
+        verify(validateDuplicateFacade).isDuplicated(중복_검사_요청_객체);
+
+        ValidateDuplicateResponse validateDuplicateResponse = andReturn(중복_검사_요청_결과, ValidateDuplicateResponse.class);
+        assertAll(
+            () -> assertThat(validateDuplicateResponse.requestType()).isEqualTo(ValidateDuplicateRequestType.MEMBER_ID),
+            () -> assertThat(validateDuplicateResponse.requestValue()).isEqualTo(중복_검사_요청_항목),
+            () -> assertThat(validateDuplicateResponse.isDuplicated()).isTrue(),
+            () -> assertThat(validateDuplicateResponse.availabilityStatus()).isEqualTo(AvailabilityStatus.UNAVAILABLE)
+        );
+    }
+
+    @Test
+    @DisplayName("[POST:201]회원 가입")
+    void signUp() throws Exception {
+        // Given
+        SignUpRequest 회원_가입_요청_객체 = FixtureCommon.withValidated().giveMeOne(SignUpRequest.class);
+
+        // When & Then
+        회원_가입_요청(회원_가입_요청_객체).created();
+        verify(memberService).createMember(회원_가입_요청_객체);
+    }
+
+    @Test
+    @DisplayName("[POST:400]회원 가입 실패:값이 잘못된 요청")
+    void throwException_WhenInvalidMethodArgument() throws Exception {
+        // When & Then
+        회원_가입_요청(유효_하지_않은_회원_가입_요청_객체).badRequest();
+    }
+}

--- a/porko-service/src/test/java/io/porko/member/controller/MemberControllerTestHelper.java
+++ b/porko-service/src/test/java/io/porko/member/controller/MemberControllerTestHelper.java
@@ -1,0 +1,45 @@
+package io.porko.member.controller;
+
+import io.porko.config.base.presentation.RequestBuilder.Expect;
+import io.porko.config.base.presentation.WebMvcTestBase;
+import io.porko.member.controller.model.AddressDto;
+import io.porko.member.controller.model.SignUpRequest;
+import io.porko.member.facade.ValidateDuplicateFacade;
+import io.porko.member.service.MemberService;
+import org.junit.jupiter.api.DisplayName;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@WebMvcTest(MemberController.class)
+@DisplayName("Controller:Member")
+class MemberControllerTestHelper extends WebMvcTestBase {
+    @MockBean
+    protected MemberService memberService;
+
+    @MockBean
+    protected ValidateDuplicateFacade validateDuplicateFacade;
+
+    private static final String MEMBER_SIGN_UP_URI = "/member/sign-up";
+    private static final String MEMBER_SIGN_UP_VALIDATE_DUPLICATE_URL = "/member/validate?{target_field}={target_value}";
+    protected final SignUpRequest 유효_하지_않은_회원_가입_요청_객체 = new SignUpRequest(
+        "",
+        "",
+        "",
+        "",
+        "",
+        new AddressDto("", ""),
+        null
+    );
+
+    protected Expect 회원_가입_요청(SignUpRequest 회원_가입_요청_정보) {
+        return post()
+            .url(MEMBER_SIGN_UP_URI)
+            .jsonContent(회원_가입_요청_정보);
+    }
+
+    protected Expect 중복_검사_요청(String 중복_검사_항목_명, String 중복_검사_항목) {
+        return get()
+            .url(MEMBER_SIGN_UP_VALIDATE_DUPLICATE_URL, 중복_검사_항목_명, 중복_검사_항목)
+            .expect();
+    }
+}

--- a/porko-service/src/test/java/io/porko/member/facade/ValidateDuplicateFacadeTest.java
+++ b/porko-service/src/test/java/io/porko/member/facade/ValidateDuplicateFacadeTest.java
@@ -1,0 +1,66 @@
+package io.porko.member.facade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import io.porko.config.base.business.ServiceTestBase;
+import io.porko.member.controller.model.AvailabilityStatus;
+import io.porko.member.controller.model.ValidateDuplicateRequest;
+import io.porko.member.controller.model.ValidateDuplicateResponse;
+import io.porko.member.exception.MemberErrorCode;
+import io.porko.member.exception.MemberException;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@DisplayName("Facade:ValidateDuplicate")
+class ValidateDuplicateFacadeTest extends ServiceTestBase {
+    private final ValidateDuplicateFacade validateDuplicateFacade;
+
+    public ValidateDuplicateFacadeTest(ValidateDuplicateFacade validateDuplicateFacade) {
+        this.validateDuplicateFacade = validateDuplicateFacade;
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    @DisplayName("중복 검사 요청 타입을 선별하고 각 타입에 적절한 중복 검사 실시 후 결과를 반환한다.")
+    void isDuplicated(final ValidateDuplicateRequest given) {
+        // When
+        ValidateDuplicateResponse actual = validateDuplicateFacade.isDuplicated(given);
+
+        // Then
+        assertThat(actual.isDuplicated()).isFalse();
+        assertThat(actual.availabilityStatus()).isEqualTo(AvailabilityStatus.AVAILABLE);
+    }
+
+    private static Stream<Arguments> isDuplicated() {
+        return Stream.of(
+            Arguments.of(ValidateDuplicateRequest.of("porkoMemberId", null)),
+            Arguments.of(ValidateDuplicateRequest.of(null, "testMember@porko.info"))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    @DisplayName("[예외]중복 여부 검사 요청 값의 형식이 유효하지 않은 경우")
+    void throwMemberException_WhenValidateDuplicateRequest(ValidateDuplicateRequest given) {
+        // When & Then
+        assertThatExceptionOfType(MemberException.class)
+            .isThrownBy(() -> validateDuplicateFacade.isDuplicated(given))
+            .extracting(MemberException::getCode)
+            .isEqualTo(MemberErrorCode.INVALID_VALIDATE_DUPLICATE_TARGET_FORMAT.name())
+        ;
+    }
+
+    private static Stream<Arguments> throwMemberException_WhenValidateDuplicateRequest() {
+        return Stream.of(
+            Arguments.of(ValidateDuplicateRequest.of("", null)),
+            Arguments.of(ValidateDuplicateRequest.of(null, "some email request")),
+            Arguments.of(ValidateDuplicateRequest.of(null, null))
+        );
+    }
+}

--- a/porko-service/src/test/java/io/porko/member/facade/dto/ValidateDuplicateRequestFieldTest.java
+++ b/porko-service/src/test/java/io/porko/member/facade/dto/ValidateDuplicateRequestFieldTest.java
@@ -1,0 +1,49 @@
+package io.porko.member.facade.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.util.AbstractMap;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@DisplayName("Facade:DTO:ValidateDuplicateRequestField")
+class ValidateDuplicateRequestFieldTest {
+    @ParameterizedTest
+    @MethodSource
+    @DisplayName("중복 검사 요청 항목 추출")
+    void create(final AbstractMap.SimpleEntry<String, Object> firstEntry, ValidateDuplicateRequestType expected) {
+        // When
+        ValidateDuplicateRequestField actual = ValidateDuplicateRequestField.of(firstEntry);
+
+        // Then
+        assertThat(actual).hasFieldOrPropertyWithValue("requestType", expected);
+    }
+
+    private static Stream<Arguments> create() {
+        return Stream.of(
+            Arguments.of(
+                new AbstractMap.SimpleEntry<>("memberId", "porkoMemberId"),
+                ValidateDuplicateRequestType.MEMBER_ID
+            ),
+            Arguments.of(new AbstractMap.SimpleEntry<>("email", "porkoMemberId@porko.info"),
+                ValidateDuplicateRequestType.EMAIL
+            )
+        );
+    }
+
+    @Test
+    @DisplayName("[예외]중복 검사 대상 항목이 아닌 경우")
+    void throwException_WhenNotValidateDuplicateTargetField() {
+        // Given
+        AbstractMap.SimpleEntry<String, Object> firstEntry = new AbstractMap.SimpleEntry<>("invalid field", "porkoMemberId");
+
+        // When & Then
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> ValidateDuplicateRequestField.of(firstEntry));
+    }
+}

--- a/porko-service/src/test/java/io/porko/member/facade/dto/ValidateDuplicateRequestTypeTest.java
+++ b/porko-service/src/test/java/io/porko/member/facade/dto/ValidateDuplicateRequestTypeTest.java
@@ -1,0 +1,41 @@
+package io.porko.member.facade.dto;
+
+import static io.porko.config.fixture.FixtureCommon.randomString;
+import static io.porko.member.exception.MemberErrorCode.INVALID_VALIDATE_DUPLICATE_TARGET_FORMAT;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
+import io.porko.member.exception.MemberException;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayName("Facade:DTO:ValidateDuplicateRequestType")
+class ValidateDuplicateRequestTypeTest {
+    @ParameterizedTest
+    @MethodSource
+    @NullAndEmptySource
+    @ValueSource(strings = {" "})
+    @DisplayName("[예외]중복 검사 요청값의 형식이 유효하지 않은 경우")
+    void throwMemberException_GivenInvalidFormatValidateDuplicatedTypeValue(String given) {
+        // When & Then
+        assertThatExceptionOfType(MemberException.class)
+            .isThrownBy(() -> ValidateDuplicateRequestType.MEMBER_ID.validateFormat(given))
+            .extracting(MemberException::getCode)
+            .isEqualTo(INVALID_VALIDATE_DUPLICATE_TARGET_FORMAT.name())
+        ;
+    }
+
+    private static Stream<Arguments> throwMemberException_GivenInvalidFormatValidateDuplicatedTypeValue() {
+        String underLength = randomString().ofMinLength(5).sample();
+        String overLength = randomString().ofMinLength(20).sample();
+
+        return Stream.of(
+            Arguments.of(underLength),
+            Arguments.of(overLength)
+        );
+    }
+}

--- a/porko-service/src/test/java/io/porko/member/repo/MemberRepoTest.java
+++ b/porko-service/src/test/java/io/porko/member/repo/MemberRepoTest.java
@@ -1,0 +1,51 @@
+package io.porko.member.repo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import io.porko.config.base.persistence.JpaTestBase;
+import io.porko.member.domain.Address;
+import io.porko.member.domain.Gender;
+import io.porko.member.domain.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Repo:Member")
+class MemberRepoTest extends JpaTestBase {
+    private final MemberRepo memberRepo;
+
+    public MemberRepoTest(MemberRepo memberRepo) {
+        this.memberRepo = memberRepo;
+    }
+
+    @Test
+    @DisplayName("회원 저장")
+    void save() {
+        // Given
+        Member given = Member.of(
+            "memberId",
+            "password",
+            "name",
+            "email",
+            "01012345678",
+            Address.of("roadName", "detail"),
+            Gender.MALE
+        );
+
+        // When
+        Member actual = memberRepo.save(given);
+
+        // Then
+        assertAll(
+            () -> assertThat(actual.getId())
+                .as("JPA PK 생성 전략에 의한 PK값 부여 여부 검증")
+                .isNotNull(),
+            () -> assertThat(actual.getCreatedAt())
+                .as("JPA AuditingListener에 의한 생성일시 부여 여부 검증")
+                .isNotNull(),
+            () -> assertThat(actual.getUpdatedAt())
+                .as("TestJpaConfiguration의 @EnableJpaAuditing(modifyOnCreate = false)설정에 의해 생성된 데이터의 수정일시 미 부여 여부 검증")
+                .isNull()
+        );
+    }
+}

--- a/porko-service/src/test/java/io/porko/member/service/MemberServiceTest.java
+++ b/porko-service/src/test/java/io/porko/member/service/MemberServiceTest.java
@@ -1,0 +1,107 @@
+package io.porko.member.service;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import io.porko.config.base.business.ServiceTestBase;
+import io.porko.config.fixture.FixtureCommon;
+import io.porko.member.controller.model.SignUpRequest;
+import io.porko.member.domain.Member;
+import io.porko.member.exception.MemberErrorCode;
+import io.porko.member.exception.MemberException;
+import io.porko.member.repo.MemberRepo;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.AdditionalAnswers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@DisplayName("Service:Member")
+class MemberServiceTest extends ServiceTestBase {
+    @Mock
+    private MemberRepo memberRepo;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    private final SignUpRequest 회원_가입_요청_객체 = FixtureCommon.dtoType().giveMeOne(SignUpRequest.class);
+
+    @Test
+    @DisplayName("회원 생성")
+    void createMember() {
+        // Given
+        회원_생성_의존성_행동_정의(회원_가입_요청_객체);
+
+        // When
+        회원_생성(회원_가입_요청_객체);
+
+        // Then
+        회원_생성_의존성_동작_검증(회원_가입_요청_객체);
+    }
+
+    private void 회원_생성_의존성_행동_정의(SignUpRequest signUpRequest) {
+        given(memberRepo.existsByMemberId(signUpRequest.memberId())).willReturn(false);
+        given(memberRepo.existsByEmail(signUpRequest.email())).willReturn(false);
+        given(memberRepo.save(any(Member.class))).will(AdditionalAnswers.returnsFirstArg());
+    }
+
+    private void 회원_생성(SignUpRequest 회원_가입_요청_객체) {
+        assertDoesNotThrow(() -> memberService.createMember(회원_가입_요청_객체));
+    }
+
+    private void 회원_생성_의존성_동작_검증(SignUpRequest 회원_가입_요청_객체) {
+        verify(memberRepo).existsByMemberId(회원_가입_요청_객체.memberId());
+        verify(memberRepo).existsByEmail(회원_가입_요청_객체.email());
+        verify(passwordEncoder).encode(회원_가입_요청_객체.password());
+        verify(memberRepo).save(any(Member.class));
+    }
+
+    @Test
+    @DisplayName("[예외]회원 생성 실패: 중복된 아이디")
+    void throwMemberException_GivenDuplicatedMemberId() {
+        // Given
+        String 중복된_회원_아이디 = 회원_가입_요청_객체.memberId();
+        given(memberRepo.existsByMemberId(중복된_회원_아이디)).willReturn(true);
+
+        // When
+        assertThatExceptionOfType(MemberException.class)
+            .isThrownBy(() -> memberService.createMember(회원_가입_요청_객체))
+            .extracting(MemberException::getCode, MemberException::getMessage)
+            .containsExactly(
+                MemberErrorCode.DUPLICATED_MEMBER_ID.name(),
+                MemberErrorCode.DUPLICATED_MEMBER_ID.getMessage().formatted(중복된_회원_아이디)
+            )
+        ;
+
+        // Then
+        verify(memberRepo).existsByMemberId(중복된_회원_아이디);
+    }
+
+    @Test
+    @DisplayName("[예외]회원 생성 실패: 중복된 이메일")
+    void throwMemberException_GivenDuplicatedEmail() {
+        // Given
+        String 중복된_회원_이메일 = 회원_가입_요청_객체.email();
+        given(memberRepo.existsByEmail(중복된_회원_이메일)).willReturn(true);
+
+        // When
+        assertThatExceptionOfType(MemberException.class)
+            .isThrownBy(() -> memberService.createMember(회원_가입_요청_객체))
+            .extracting(MemberException::getCode, MemberException::getMessage)
+            .containsExactly(
+                MemberErrorCode.DUPLICATED_EMAIL.name(),
+                MemberErrorCode.DUPLICATED_EMAIL.getMessage().formatted(중복된_회원_이메일)
+            )
+        ;
+
+        // Then
+        verify(memberRepo).existsByEmail(중복된_회원_이메일);
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,2 @@
 rootProject.name = "porko"
-include("porko-common")
+include("porko-common", "porko-service")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,2 @@
 rootProject.name = "porko"
+include("porko-common")


### PR DESCRIPTION
## #️⃣연관된 이슈

> #2 

## 📝작업 내용

- [JPA 관련 공통 설정 추가](https://github.com/project-porko/porko-service/commit/84d575530f73363d59cd57941389e88ee463a539)
- [JPA Test 관련 공통 설정 추가](https://github.com/project-porko/porko-service/commit/a57bd9021293e9668d89fc7bdf5388d0925523c2)
- [Spring Security 관련 공통 설정 추가](https://github.com/project-porko/porko-service/commit/e6e775c008ff38d188b40d85b6f2809a1f0fb3ed)
- [test 환경에서 인증/인가 처리를 위한 Security Test Config 설정](https://github.com/project-porko/porko-service/commit/dbc315490d7ac0d2167e75c1f6ebad2e5cb2e6dc)
- [service, facade 등 mocking을 이용한 business 계층 test 관련 설정 부 추가](https://github.com/project-porko/porko-service/commit/5c8b6fd00a3404d0010877d80a6c65eeaaeb80e7)
- [Exception 처리를 위한 Exception Handler](https://github.com/project-porko/porko-service/commit/b587d1f8e9364080d4abbea32abe75a38a4dc2eb)
- [Presentation 계층 Test 관련 공통 설정 추가](https://github.com/project-porko/porko-service/commit/33a9b07a9360400ad5e86f8f6b6811bbccd22eee)


## 💬리뷰 요구사항
Domain 별로 서버가 분리될 수 있는 경우를 염두하여 Application 구동 시 필요한 공통 설정을 별도 모듈로 추출하였습니다. 크게 운영 환경과 테스트 환경으로 구분하여 각 환경에 필요한 설정 부를 구현 하였습니다. 

필요하다고 생각한 공통 설정 부를 한번에 작업한 탓에 커밋이 매우 커졌네요. 다음 커밋은 작게 작성해 보겠습니다. 

보기 불편하시겠지만 미흡한 부분 혹은 잘못 작성된 부분이 있다면 코멘트 부탁드립니다.

This Closes #2 