### PR TITLE
feat :회원 가입 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,4 +224,7 @@ gradle-app.setting
 ### fixture-monkey
 .jqwik-database
 
+### intellij qodana plugin
+qodana.yaml
+
 # End of https://www.toptal.com/developers/gitignore/api/java,gradle,intellij+all,windows,macos,visualstudiocode

--- a/.gitignore
+++ b/.gitignore
@@ -221,4 +221,7 @@ gradle-app.setting
 # Java heap dump
 *.hprof
 
+### fixture-monkey
+.jqwik-database
+
 # End of https://www.toptal.com/developers/gitignore/api/java,gradle,intellij+all,windows,macos,visualstudiocode

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,6 +39,7 @@ subprojects {
         compileOnly("org.projectlombok:lombok")
 
         testImplementation("org.springframework.boot:spring-boot-starter-test")
+        testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter:1.0.14")
     }
 }
 

--- a/porko-common/src/main/java/io/porko/exception/response/ErrorCode.java
+++ b/porko-common/src/main/java/io/porko/exception/response/ErrorCode.java
@@ -1,5 +1,6 @@
 package io.porko.exception.response;
 
+import static io.porko.utils.ConvertUtils.convertToConstants;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.UNSUPPORTED_MEDIA_TYPE;
@@ -45,12 +46,7 @@ public enum ErrorCode {
     }
 
     private static String convertToErrorCodeName(String className) {
-        String regex = "([a-z])([A-Z])";
-        String replacement = "$1_$2";
         String exceptKeyword = "_Exception";
-
-        return className.replaceAll(regex, replacement)
-            .replace(exceptKeyword, "")
-            .toUpperCase();
+        return convertToConstants(className).replace(exceptKeyword, "");
     }
 }

--- a/porko-common/src/main/java/io/porko/utils/ConvertUtils.java
+++ b/porko-common/src/main/java/io/porko/utils/ConvertUtils.java
@@ -1,0 +1,36 @@
+package io.porko.utils;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class ConvertUtils {
+    public static String convertToConstants(String value) {
+        String regex = "([a-z])([A-Z])";
+        String replacement = "$1_$2";
+
+        return value.replaceAll(regex, replacement)
+            .toUpperCase();
+    }
+
+    public static Map<String, Object> convertToMap(Object obj) {
+        try {
+            if (Objects.isNull(obj)) {
+                return Collections.emptyMap();
+            }
+            Map<String, Object> convertMap = new HashMap<>();
+
+            Field[] fields = obj.getClass().getDeclaredFields();
+
+            for (Field field : fields) {
+                field.setAccessible(true);
+                convertMap.put(field.getName(), field.get(obj));
+            }
+            return convertMap;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/porko-common/src/main/java/io/porko/utils/ResponseEntityUtils.java
+++ b/porko-common/src/main/java/io/porko/utils/ResponseEntityUtils.java
@@ -1,0 +1,9 @@
+package io.porko.utils;
+
+import org.springframework.http.ResponseEntity;
+
+public class ResponseEntityUtils {
+    public static ResponseEntity<Void> created(String uriFormat, Object path) {
+        return ResponseEntity.created(UriComponentUtils.makeUrl(uriFormat, path)).build();
+    }
+}

--- a/porko-common/src/main/java/io/porko/utils/UriComponentUtils.java
+++ b/porko-common/src/main/java/io/porko/utils/UriComponentUtils.java
@@ -1,0 +1,12 @@
+package io.porko.utils;
+
+import java.net.URI;
+import org.springframework.web.util.UriComponentsBuilder;
+
+public class UriComponentUtils {
+    public static <T> URI makeUrl(String baseUri, T path) {
+        return UriComponentsBuilder.fromUriString(baseUri)
+            .buildAndExpand(path)
+            .toUri();
+    }
+}

--- a/porko-common/src/test/java/io/porko/config/base/presentation/RequestBuilder.java
+++ b/porko-common/src/test/java/io/porko/config/base/presentation/RequestBuilder.java
@@ -33,8 +33,10 @@ public class RequestBuilder {
 
     private HttpMethod method;
 
-    private final Map<String, Object> headers = new HashMap<>();
-    private MediaType contentType;
+    private final Map<String, Object> headers = new HashMap<>() {{
+        put("Content-Type", MediaType.APPLICATION_JSON);
+        put("Accept", MediaType.APPLICATION_JSON);
+    }};
 
     private Object content;
 
@@ -111,7 +113,6 @@ public class RequestBuilder {
 
     public class Content {
         public Expect jsonContent(final Object object) {
-            contentType = MediaType.APPLICATION_JSON;
             content = object;
             return new Expect();
         }
@@ -181,13 +182,12 @@ public class RequestBuilder {
                 urlVariables.toArray()
             );
 
-        for (String header : headers.keySet()) {
-            request.header(header, headers.get(header));
+        for (String key : headers.keySet()) {
+            request.header(key, headers.get(key));
         }
 
         if (content != null) {
-            request.contentType(contentType)
-                .content(objectMapper.writeValueAsString(content));
+            request.content(objectMapper.writeValueAsString(content));
         }
 
         return mockMvc.perform(request)

--- a/porko-common/src/test/java/io/porko/config/fixture/FixtureCommon.java
+++ b/porko-common/src/test/java/io/porko/config/fixture/FixtureCommon.java
@@ -6,6 +6,8 @@ import com.navercorp.fixturemonkey.api.introspector.BuilderArbitraryIntrospector
 import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
 import com.navercorp.fixturemonkey.jakarta.validation.plugin.JakartaValidationPlugin;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.arbitraries.StringArbitrary;
 
 public class FixtureCommon {
     private static final FixtureMonkeyBuilder builder = FixtureMonkey.builder();
@@ -36,5 +38,9 @@ public class FixtureCommon {
         return builder
             .objectIntrospector(BuilderArbitraryIntrospector.INSTANCE)
             .build();
+    }
+
+    public static StringArbitrary randomString() {
+        return Arbitraries.strings();
     }
 }

--- a/porko-service/build.gradle.kts
+++ b/porko-service/build.gradle.kts
@@ -1,7 +1,9 @@
+val testSourceSet: SourceSetOutput = project(":porko-common").sourceSets["test"].output
 
 dependencies {
     implementation(project(":porko-common"))
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 
     testRuntimeOnly("com.h2database:h2")
+    testImplementation(testSourceSet)
 }

--- a/porko-service/build.gradle.kts
+++ b/porko-service/build.gradle.kts
@@ -3,6 +3,9 @@ val testSourceSet: SourceSetOutput = project(":porko-common").sourceSets["test"]
 dependencies {
     implementation(project(":porko-common"))
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
 
     testRuntimeOnly("com.h2database:h2")
     testImplementation(testSourceSet)

--- a/porko-service/build.gradle.kts
+++ b/porko-service/build.gradle.kts
@@ -1,0 +1,7 @@
+
+dependencies {
+    implementation(project(":porko-common"))
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+
+    testRuntimeOnly("com.h2database:h2")
+}

--- a/porko-service/src/main/java/io/porko/PorkoServiceApp.java
+++ b/porko-service/src/main/java/io/porko/PorkoServiceApp.java
@@ -1,0 +1,12 @@
+package io.porko;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class PorkoServiceApp {
+    public static void main(String[] args) {
+        System.setProperty("spring.config.name", "application, application-service");
+        SpringApplication.run(PorkoServiceApp.class, args);
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/controller/MemberController.java
+++ b/porko-service/src/main/java/io/porko/member/controller/MemberController.java
@@ -1,0 +1,37 @@
+package io.porko.member.controller;
+
+import static io.porko.member.controller.MemberController.MEMBER_BASE_URI;
+
+import io.porko.member.controller.model.SignUpRequest;
+import io.porko.member.service.MemberService;
+import io.porko.utils.ResponseEntityUtils;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping(
+    value = MEMBER_BASE_URI,
+    consumes = MediaType.APPLICATION_JSON_VALUE,
+    produces = MediaType.APPLICATION_JSON_VALUE
+)
+@RestController
+@RequiredArgsConstructor
+public class MemberController {
+    static final String MEMBER_BASE_URI = "/member";
+    private static final String GET_AN_MEMBER_URI_FORMAT = MEMBER_BASE_URI.concat("/{id}");
+
+    private final MemberService memberService;
+
+    @PostMapping("sign-up")
+    ResponseEntity<Void> signUp(@Valid @RequestBody SignUpRequest signUpRequest) {
+        return ResponseEntityUtils.created(
+            GET_AN_MEMBER_URI_FORMAT,
+            memberService.createMember(signUpRequest)
+        );
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/controller/MemberController.java
+++ b/porko-service/src/main/java/io/porko/member/controller/MemberController.java
@@ -3,15 +3,20 @@ package io.porko.member.controller;
 import static io.porko.member.controller.MemberController.MEMBER_BASE_URI;
 
 import io.porko.member.controller.model.SignUpRequest;
+import io.porko.member.controller.model.ValidateDuplicateRequest;
+import io.porko.member.controller.model.ValidateDuplicateResponse;
+import io.porko.member.facade.ValidateDuplicateFacade;
 import io.porko.member.service.MemberService;
 import io.porko.utils.ResponseEntityUtils;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping(
@@ -25,7 +30,20 @@ public class MemberController {
     static final String MEMBER_BASE_URI = "/member";
     private static final String GET_AN_MEMBER_URI_FORMAT = MEMBER_BASE_URI.concat("/{id}");
 
+    private final ValidateDuplicateFacade validateDuplicateFacade;
     private final MemberService memberService;
+
+    @GetMapping("validate")
+    ResponseEntity<ValidateDuplicateResponse> validateDuplicate(
+        @RequestParam(name = "memberId", required = false) String memberId,
+        @RequestParam(name = "email", required = false) String email
+    ) {
+        System.out.println(memberId);
+        ValidateDuplicateResponse duplicated = validateDuplicateFacade.isDuplicated(
+            ValidateDuplicateRequest.of(memberId, email)
+        );
+        return ResponseEntity.ok(duplicated);
+    }
 
     @PostMapping("sign-up")
     ResponseEntity<Void> signUp(@Valid @RequestBody SignUpRequest signUpRequest) {

--- a/porko-service/src/main/java/io/porko/member/controller/model/AddressDto.java
+++ b/porko-service/src/main/java/io/porko/member/controller/model/AddressDto.java
@@ -1,0 +1,12 @@
+package io.porko.member.controller.model;
+
+import io.porko.member.domain.Address;
+
+public record AddressDto(
+    String roadName,
+    String detail
+) {
+    public Address toEntity() {
+        return Address.of(roadName, detail);
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/controller/model/AvailabilityStatus.java
+++ b/porko-service/src/main/java/io/porko/member/controller/model/AvailabilityStatus.java
@@ -1,0 +1,12 @@
+package io.porko.member.controller.model;
+
+public enum AvailabilityStatus {
+    AVAILABLE, UNAVAILABLE;
+
+    public static AvailabilityStatus valueOf(boolean isDuplicated) {
+        if (isDuplicated) {
+            return UNAVAILABLE;
+        }
+        return AVAILABLE;
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/controller/model/SignUpRequest.java
+++ b/porko-service/src/main/java/io/porko/member/controller/model/SignUpRequest.java
@@ -2,14 +2,35 @@ package io.porko.member.controller.model;
 
 import io.porko.member.domain.Gender;
 import io.porko.member.domain.Member;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record SignUpRequest(
+    @NotBlank
+    @Size(min = 6, max = 20)
     String memberId,
+
+    @NotBlank
     String password,
+
+    @NotBlank
+    @Size(max = 10)
     String name,
+
+    @NotBlank
+    @Size(max = 40)
+    @Email
     String email,
+
+    @NotBlank
+    @Size(max = 11)
     String phoneNumber,
+
     AddressDto address,
+
+    @NotNull
     Gender gender
 ) {
     public Member toEntity(String encodedPassword) {

--- a/porko-service/src/main/java/io/porko/member/controller/model/SignUpRequest.java
+++ b/porko-service/src/main/java/io/porko/member/controller/model/SignUpRequest.java
@@ -1,0 +1,26 @@
+package io.porko.member.controller.model;
+
+import io.porko.member.domain.Gender;
+import io.porko.member.domain.Member;
+
+public record SignUpRequest(
+    String memberId,
+    String password,
+    String name,
+    String email,
+    String phoneNumber,
+    AddressDto address,
+    Gender gender
+) {
+    public Member toEntity(String encodedPassword) {
+        return Member.of(
+            memberId,
+            encodedPassword,
+            name,
+            email,
+            phoneNumber,
+            address.toEntity(),
+            gender
+        );
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/controller/model/ValidateDuplicateRequest.java
+++ b/porko-service/src/main/java/io/porko/member/controller/model/ValidateDuplicateRequest.java
@@ -1,0 +1,10 @@
+package io.porko.member.controller.model;
+
+public record ValidateDuplicateRequest(
+    String memberId,
+    String email
+) {
+    public static ValidateDuplicateRequest of(String memberId, String email) {
+        return new ValidateDuplicateRequest(memberId, email);
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/controller/model/ValidateDuplicateResponse.java
+++ b/porko-service/src/main/java/io/porko/member/controller/model/ValidateDuplicateResponse.java
@@ -1,0 +1,20 @@
+package io.porko.member.controller.model;
+
+import io.porko.member.facade.dto.ValidateDuplicateRequestField;
+import io.porko.member.facade.dto.ValidateDuplicateRequestType;
+
+public record ValidateDuplicateResponse(
+    ValidateDuplicateRequestType requestType,
+    String requestValue,
+    boolean isDuplicated,
+    AvailabilityStatus availabilityStatus
+) {
+    public static ValidateDuplicateResponse of(ValidateDuplicateRequestField requestField, boolean isDuplicated) {
+        return new ValidateDuplicateResponse(
+            requestField.requestType(),
+            requestField.value(),
+            isDuplicated,
+            AvailabilityStatus.valueOf(isDuplicated)
+        );
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/domain/Address.java
+++ b/porko-service/src/main/java/io/porko/member/domain/Address.java
@@ -1,11 +1,24 @@
 package io.porko.member.domain;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.AccessType;
+import org.springframework.data.annotation.AccessType.Type;
 
+@Getter
+@Embeddable
+@AccessType(Type.FIELD)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Address {
+    @Column(nullable = false)
     private String roadName;
+    
+    @Column(nullable = false, length = 30)
     private String detail;
 
     public static Address of(String roadName, String detail) {

--- a/porko-service/src/main/java/io/porko/member/domain/Address.java
+++ b/porko-service/src/main/java/io/porko/member/domain/Address.java
@@ -1,0 +1,14 @@
+package io.porko.member.domain;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Address {
+    private String roadName;
+    private String detail;
+
+    public static Address of(String roadName, String detail) {
+        return new Address(roadName, detail);
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/domain/Gender.java
+++ b/porko-service/src/main/java/io/porko/member/domain/Gender.java
@@ -1,0 +1,5 @@
+package io.porko.member.domain;
+
+public enum Gender {
+    MALE, FEMALE
+}

--- a/porko-service/src/main/java/io/porko/member/domain/Member.java
+++ b/porko-service/src/main/java/io/porko/member/domain/Member.java
@@ -1,0 +1,41 @@
+package io.porko.member.domain;
+
+public class Member {
+    private Long id;
+    private String memberId;
+    private String password;
+    private String name;
+    private String email;
+    private String phoneNumber;
+    private Address address;
+    private Gender gender;
+
+    public Member(
+        String memberId,
+        String password,
+        String name,
+        String email,
+        String phoneNumber,
+        Address address,
+        Gender gender
+    ) {
+        this.memberId = memberId;
+        this.password = password;
+        this.name = name;
+        this.email = email;
+        this.phoneNumber = phoneNumber;
+        this.address = address;
+        this.gender = gender;
+    }
+
+    public static Member of(String memberId,
+        String password,
+        String name,
+        String email,
+        String phoneNumber,
+        Address address,
+        Gender gender
+    ) {
+        return new Member(memberId, password, name, email, phoneNumber, address, gender);
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/domain/Member.java
+++ b/porko-service/src/main/java/io/porko/member/domain/Member.java
@@ -50,7 +50,7 @@ public class Member extends TimeMetaFields {
     @Enumerated(EnumType.STRING)
     private Gender gender;
 
-    public Member(
+    private Member(
         String memberId,
         String password,
         String name,

--- a/porko-service/src/main/java/io/porko/member/domain/Member.java
+++ b/porko-service/src/main/java/io/porko/member/domain/Member.java
@@ -1,13 +1,53 @@
 package io.porko.member.domain;
 
-public class Member {
+import io.porko.config.jpa.auditor.TimeMetaFields;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(
+    uniqueConstraints = {
+        @UniqueConstraint(name = "UK_MEMBER_ID", columnNames = "member_id"),
+        @UniqueConstraint(name = "UK_MEMBER_EMAIL", columnNames = "email")
+    })
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends TimeMetaFields {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false, length = 20)
     private String memberId;
+
+    @Column(nullable = false)
     private String password;
+
+    @Column(nullable = false, length = 10)
     private String name;
+
+    @Column(nullable = false, length = 40)
     private String email;
+
+    @Column(nullable = false, length = 11)
     private String phoneNumber;
+
+    @Embedded
     private Address address;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     private Gender gender;
 
     public Member(

--- a/porko-service/src/main/java/io/porko/member/exception/MemberErrorCode.java
+++ b/porko-service/src/main/java/io/porko/member/exception/MemberErrorCode.java
@@ -1,12 +1,16 @@
 package io.porko.member.exception;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
 public enum MemberErrorCode {
-    DUPLICATED_MEMBER_ID(HttpStatus.BAD_REQUEST, "중복된 ID입니다. [request: %s]"),
-    DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "중복된 이메일입니다. [request: %s]"),
+    DUPLICATED_MEMBER_ID(BAD_REQUEST, "중복된 ID입니다. [request: %s]"),
+    DUPLICATED_EMAIL(BAD_REQUEST, "중복된 이메일입니다. [request: %s]"),
+    INVALID_VALIDATE_DUPLICATE_TARGET_FORMAT(BAD_REQUEST, "중복 검사 대상 항목의 형식이 유효하지 않습니다. [request: %s]"),
+    UNSUPPORTED_VALIDATE_DUPLICATE_TARGET(BAD_REQUEST, "지원하지 않는 중복 검사 대상 항목입니다. [request: %s]"),
     ;
 
     private final HttpStatus status;

--- a/porko-service/src/main/java/io/porko/member/exception/MemberErrorCode.java
+++ b/porko-service/src/main/java/io/porko/member/exception/MemberErrorCode.java
@@ -1,0 +1,23 @@
+package io.porko.member.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum MemberErrorCode {
+    DUPLICATED_MEMBER_ID(HttpStatus.BAD_REQUEST, "중복된 ID입니다. [request: %s]"),
+    DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "중복된 이메일입니다. [request: %s]"),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+
+    MemberErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public String formattingErrorMessage(Object... objects) {
+        return getMessage().formatted(objects);
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/exception/MemberException.java
+++ b/porko-service/src/main/java/io/porko/member/exception/MemberException.java
@@ -1,0 +1,16 @@
+package io.porko.member.exception;
+
+import io.porko.exception.BusinessException;
+
+public class MemberException extends BusinessException {
+    private MemberErrorCode errorCode;
+    private String message;
+
+    public MemberException(MemberErrorCode errorCode, Object... args) {
+        super(
+            errorCode.getStatus(),
+            errorCode.name(),
+            errorCode.formattingErrorMessage(args)
+        );
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/facade/ValidateDuplicateFacade.java
+++ b/porko-service/src/main/java/io/porko/member/facade/ValidateDuplicateFacade.java
@@ -1,0 +1,45 @@
+package io.porko.member.facade;
+
+import static io.porko.utils.ConvertUtils.convertToMap;
+
+import io.porko.member.controller.model.ValidateDuplicateRequest;
+import io.porko.member.controller.model.ValidateDuplicateResponse;
+import io.porko.member.exception.MemberErrorCode;
+import io.porko.member.exception.MemberException;
+import io.porko.member.facade.dto.ValidateDuplicateRequestField;
+import io.porko.member.facade.strategy.ValidateDuplicateStrategy;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ValidateDuplicateFacade {
+    private final List<ValidateDuplicateStrategy> validateDuplicateStrategies;
+
+    public ValidateDuplicateResponse isDuplicated(ValidateDuplicateRequest validateDuplicateRequest) {
+        ValidateDuplicateRequestField requestField = extractValidateDuplicateRequestField(validateDuplicateRequest);
+
+        return validateDuplicateStrategies.stream()
+            .filter(it -> it.isSupport(requestField.requestType()))
+            .findAny()
+            .orElseThrow(() -> new MemberException(MemberErrorCode.UNSUPPORTED_VALIDATE_DUPLICATE_TARGET, validateDuplicateRequest))
+            .isDuplicated(requestField)
+            ;
+    }
+
+    private ValidateDuplicateRequestField extractValidateDuplicateRequestField(ValidateDuplicateRequest validateDuplicateRequest) {
+        Map<String, Object> validateDuplicateRequestMap = convertToMap(validateDuplicateRequest);
+        return extractRequestEntry(validateDuplicateRequestMap);
+    }
+
+    private ValidateDuplicateRequestField extractRequestEntry(Map<String, Object> rquestMap) {
+        return rquestMap.entrySet().stream()
+            .filter(entry -> entry.getValue() != null)
+            .map(ValidateDuplicateRequestField::of)
+            .findAny()
+            .orElseThrow(() -> new MemberException(MemberErrorCode.INVALID_VALIDATE_DUPLICATE_TARGET_FORMAT, rquestMap))
+            ;
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/facade/dto/ValidateDuplicateRequestField.java
+++ b/porko-service/src/main/java/io/porko/member/facade/dto/ValidateDuplicateRequestField.java
@@ -1,0 +1,30 @@
+package io.porko.member.facade.dto;
+
+import static io.porko.utils.ConvertUtils.convertToConstants;
+
+import java.util.Map.Entry;
+
+public record ValidateDuplicateRequestField(
+    ValidateDuplicateRequestType requestType,
+    String value
+) {
+    public static ValidateDuplicateRequestField of(Entry<String, Object> entry) {
+        ValidateDuplicateRequestType requestType = toValidateType(entry.getKey());
+        String value = castToString(entry.getValue());
+        requestType.validateFormat(value);
+
+        return new ValidateDuplicateRequestField(
+            requestType,
+            value
+        );
+    }
+
+    private static ValidateDuplicateRequestType toValidateType(String requestField) {
+        String ValidateDuplicateRequestTypeConstants = convertToConstants(requestField);
+        return ValidateDuplicateRequestType.valueOf(ValidateDuplicateRequestTypeConstants);
+    }
+
+    public static String castToString(Object value) {
+        return (String) value;
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/facade/dto/ValidateDuplicateRequestType.java
+++ b/porko-service/src/main/java/io/porko/member/facade/dto/ValidateDuplicateRequestType.java
@@ -1,0 +1,36 @@
+package io.porko.member.facade.dto;
+
+import static java.util.regex.Pattern.compile;
+
+import io.porko.member.exception.MemberErrorCode;
+import io.porko.member.exception.MemberException;
+import java.util.regex.Pattern;
+
+public enum ValidateDuplicateRequestType {
+    MEMBER_ID(compile("^[a-zA-Z0-9]{6,20}$")),
+    EMAIL(compile("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$"));
+
+    private final Pattern pattern;
+
+    ValidateDuplicateRequestType(Pattern pattern) {
+        this.pattern = pattern;
+    }
+
+    public void validateFormat(String value) {
+        if (value == null || isNotMatched(value)) {
+            throw new MemberException(MemberErrorCode.INVALID_VALIDATE_DUPLICATE_TARGET_FORMAT, value);
+        }
+    }
+
+    private boolean isNotMatched(String value) {
+        return !pattern.matcher(value).matches();
+    }
+
+    public boolean isMemberId() {
+        return this == MEMBER_ID;
+    }
+
+    public boolean isEmail() {
+        return this == EMAIL;
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/facade/strategy/EmailDuplicateStrategy.java
+++ b/porko-service/src/main/java/io/porko/member/facade/strategy/EmailDuplicateStrategy.java
@@ -1,0 +1,27 @@
+package io.porko.member.facade.strategy;
+
+import io.porko.member.controller.model.ValidateDuplicateResponse;
+import io.porko.member.facade.dto.ValidateDuplicateRequestField;
+import io.porko.member.facade.dto.ValidateDuplicateRequestType;
+import io.porko.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EmailDuplicateStrategy implements ValidateDuplicateStrategy {
+    private final MemberService memberService;
+
+    @Override
+    public ValidateDuplicateResponse isDuplicated(ValidateDuplicateRequestField requestField) {
+        return ValidateDuplicateResponse.of(
+            requestField,
+            memberService.isDuplicatedEmail(requestField.value())
+        );
+    }
+
+    @Override
+    public boolean isSupport(ValidateDuplicateRequestType requestType) {
+        return requestType.isEmail();
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/facade/strategy/MemberIdDuplicateStrategy.java
+++ b/porko-service/src/main/java/io/porko/member/facade/strategy/MemberIdDuplicateStrategy.java
@@ -1,0 +1,27 @@
+package io.porko.member.facade.strategy;
+
+import io.porko.member.controller.model.ValidateDuplicateResponse;
+import io.porko.member.facade.dto.ValidateDuplicateRequestField;
+import io.porko.member.facade.dto.ValidateDuplicateRequestType;
+import io.porko.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberIdDuplicateStrategy implements ValidateDuplicateStrategy {
+    private final MemberService memberService;
+
+    @Override
+    public ValidateDuplicateResponse isDuplicated(ValidateDuplicateRequestField requestField) {
+        return ValidateDuplicateResponse.of(
+            requestField,
+            memberService.isDuplicatedMemberId(requestField.value())
+        );
+    }
+
+    @Override
+    public boolean isSupport(ValidateDuplicateRequestType requestType) {
+        return requestType.isMemberId();
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/facade/strategy/ValidateDuplicateStrategy.java
+++ b/porko-service/src/main/java/io/porko/member/facade/strategy/ValidateDuplicateStrategy.java
@@ -1,0 +1,11 @@
+package io.porko.member.facade.strategy;
+
+import io.porko.member.controller.model.ValidateDuplicateResponse;
+import io.porko.member.facade.dto.ValidateDuplicateRequestField;
+import io.porko.member.facade.dto.ValidateDuplicateRequestType;
+
+public interface ValidateDuplicateStrategy {
+    ValidateDuplicateResponse isDuplicated(ValidateDuplicateRequestField requestField);
+
+    boolean isSupport(ValidateDuplicateRequestType requestType);
+}

--- a/porko-service/src/main/java/io/porko/member/repo/MemberRepo.java
+++ b/porko-service/src/main/java/io/porko/member/repo/MemberRepo.java
@@ -1,0 +1,7 @@
+package io.porko.member.repo;
+
+import io.porko.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepo extends JpaRepository<Member, Long> {
+}

--- a/porko-service/src/main/java/io/porko/member/repo/MemberRepo.java
+++ b/porko-service/src/main/java/io/porko/member/repo/MemberRepo.java
@@ -4,4 +4,7 @@ import io.porko.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepo extends JpaRepository<Member, Long> {
+    boolean existsByEmail(String email);
+
+    boolean existsByMemberId(String memberId);
 }

--- a/porko-service/src/main/java/io/porko/member/service/MemberService.java
+++ b/porko-service/src/main/java/io/porko/member/service/MemberService.java
@@ -1,0 +1,53 @@
+package io.porko.member.service;
+
+import static io.porko.member.exception.MemberErrorCode.DUPLICATED_EMAIL;
+import static io.porko.member.exception.MemberErrorCode.DUPLICATED_MEMBER_ID;
+
+import io.porko.member.controller.model.SignUpRequest;
+import io.porko.member.exception.MemberException;
+import io.porko.member.repo.MemberRepo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepo memberRepo;
+    private final PasswordEncoder passwordEncoder;
+
+    public boolean isDuplicatedMemberId(String memberId) {
+        return memberRepo.existsByMemberId(memberId);
+    }
+
+    public boolean isDuplicatedEmail(String email) {
+        return memberRepo.existsByEmail(email);
+    }
+
+    @Transactional
+    public Long createMember(SignUpRequest signUpRequest) {
+        checkDuplicatedMemberId(signUpRequest.memberId());
+        checkDuplicatedEmail(signUpRequest.email());
+        String encryptedPassword = encryptPassword(signUpRequest.password());
+
+        return memberRepo.save(signUpRequest.toEntity(encryptedPassword)).getId();
+    }
+
+    private void checkDuplicatedMemberId(String memberId) {
+        if (isDuplicatedMemberId(memberId)) {
+            throw new MemberException(DUPLICATED_MEMBER_ID, memberId);
+        }
+    }
+
+    private void checkDuplicatedEmail(String email) {
+        if (isDuplicatedEmail(email)) {
+            throw new MemberException(DUPLICATED_EMAIL, email);
+        }
+    }
+
+    private String encryptPassword(String password) {
+        return passwordEncoder.encode(password);
+    }
+}

--- a/porko-service/src/test/java/io/porko/member/controller/MemberControllerTest.java
+++ b/porko-service/src/test/java/io/porko/member/controller/MemberControllerTest.java
@@ -1,14 +1,79 @@
 package io.porko.member.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 import io.porko.config.fixture.FixtureCommon;
+import io.porko.member.controller.model.AvailabilityStatus;
 import io.porko.member.controller.model.SignUpRequest;
+import io.porko.member.controller.model.ValidateDuplicateRequest;
+import io.porko.member.controller.model.ValidateDuplicateResponse;
+import io.porko.member.facade.dto.ValidateDuplicateRequestField;
+import io.porko.member.facade.dto.ValidateDuplicateRequestType;
+import java.util.AbstractMap.SimpleEntry;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.ResultActions;
 
 @DisplayName("Controller:Member")
 class MemberControllerTest extends MemberControllerTestHelper {
+
+    @Test
+    @DisplayName("[GET:200]회원 아이디 중복 검사 : 아이디가 중복되지 않은 경우")
+    void validateMemberIdDuplicate_WhenNotDuplicatedMemberId() throws Exception {
+        // Given
+        String 중복_검사_요청_항목_명 = "memberId";
+        String 중복_검사_요청_항목 = "porkoId";
+        ValidateDuplicateRequest 중복_검사_요청_객체 = ValidateDuplicateRequest.of(중복_검사_요청_항목, null);
+        ValidateDuplicateRequestField 중목_검사_요청_항목 = ValidateDuplicateRequestField.of(new SimpleEntry<>(중복_검사_요청_항목_명, 중복_검사_요청_항목));
+
+        given(validateDuplicateFacade.isDuplicated(중복_검사_요청_객체))
+            .willReturn(ValidateDuplicateResponse.of(중목_검사_요청_항목, false));
+
+        // When
+        ResultActions 중복_검사_요청_결과 = 중복_검사_요청(중복_검사_요청_항목_명, 중복_검사_요청_항목).ok();
+
+        // Then
+        verify(validateDuplicateFacade).isDuplicated(중복_검사_요청_객체);
+
+        ValidateDuplicateResponse 중복_검사_요청_응답 = andReturn(중복_검사_요청_결과, ValidateDuplicateResponse.class);
+        assertAll(
+            () -> assertThat(중복_검사_요청_응답.requestType()).isEqualTo(ValidateDuplicateRequestType.MEMBER_ID),
+            () -> assertThat(중복_검사_요청_응답.requestValue()).isEqualTo(중복_검사_요청_항목),
+            () -> assertThat(중복_검사_요청_응답.isDuplicated()).isFalse(),
+            () -> assertThat(중복_검사_요청_응답.availabilityStatus()).isEqualTo(AvailabilityStatus.AVAILABLE)
+        );
+    }
+
+    @Test
+    @DisplayName("[GET:200]회원 아이디 중복 검사 : 아이디가 중복된 경우")
+    void validateMemberIdDuplicate_WhenDuplicatedMemberId() throws Exception {
+        // Given
+        String 중복_검사_요청_항목_명 = "memberId";
+        String 중복_검사_요청_항목 = "porkoId";
+        ValidateDuplicateRequest 중복_검사_요청_객체 = ValidateDuplicateRequest.of(중복_검사_요청_항목, null);
+        ValidateDuplicateRequestField 중목_검사_요청_항목 = ValidateDuplicateRequestField.of(new SimpleEntry<>(중복_검사_요청_항목_명, 중복_검사_요청_항목));
+
+        given(validateDuplicateFacade.isDuplicated(중복_검사_요청_객체))
+            .willReturn(ValidateDuplicateResponse.of(중목_검사_요청_항목, true));
+
+        // When
+        ResultActions 중복_검사_요청_결과 = 중복_검사_요청(중복_검사_요청_항목_명, 중복_검사_요청_항목).ok();
+
+        // Then
+        verify(validateDuplicateFacade).isDuplicated(중복_검사_요청_객체);
+
+        ValidateDuplicateResponse validateDuplicateResponse = andReturn(중복_검사_요청_결과, ValidateDuplicateResponse.class);
+        assertAll(
+            () -> assertThat(validateDuplicateResponse.requestType()).isEqualTo(ValidateDuplicateRequestType.MEMBER_ID),
+            () -> assertThat(validateDuplicateResponse.requestValue()).isEqualTo(중복_검사_요청_항목),
+            () -> assertThat(validateDuplicateResponse.isDuplicated()).isTrue(),
+            () -> assertThat(validateDuplicateResponse.availabilityStatus()).isEqualTo(AvailabilityStatus.UNAVAILABLE)
+        );
+    }
+
     @Test
     @DisplayName("[POST:201]회원 가입")
     void signUp() throws Exception {

--- a/porko-service/src/test/java/io/porko/member/controller/MemberControllerTest.java
+++ b/porko-service/src/test/java/io/porko/member/controller/MemberControllerTest.java
@@ -1,0 +1,29 @@
+package io.porko.member.controller;
+
+import static org.mockito.Mockito.verify;
+
+import io.porko.config.fixture.FixtureCommon;
+import io.porko.member.controller.model.SignUpRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Controller:Member")
+class MemberControllerTest extends MemberControllerTestHelper {
+    @Test
+    @DisplayName("[POST:201]회원 가입")
+    void signUp() throws Exception {
+        // Given
+        SignUpRequest 회원_가입_요청_객체 = FixtureCommon.withValidated().giveMeOne(SignUpRequest.class);
+
+        // When & Then
+        회원_가입_요청(회원_가입_요청_객체).created();
+        verify(memberService).createMember(회원_가입_요청_객체);
+    }
+
+    @Test
+    @DisplayName("[POST:400]회원 가입 실패:값이 잘못된 요청")
+    void throwException_WhenInvalidMethodArgument() throws Exception {
+        // When & Then
+        회원_가입_요청(유효_하지_않은_회원_가입_요청_객체).badRequest();
+    }
+}

--- a/porko-service/src/test/java/io/porko/member/controller/MemberControllerTestHelper.java
+++ b/porko-service/src/test/java/io/porko/member/controller/MemberControllerTestHelper.java
@@ -4,6 +4,7 @@ import io.porko.config.base.presentation.RequestBuilder.Expect;
 import io.porko.config.base.presentation.WebMvcTestBase;
 import io.porko.member.controller.model.AddressDto;
 import io.porko.member.controller.model.SignUpRequest;
+import io.porko.member.facade.ValidateDuplicateFacade;
 import io.porko.member.service.MemberService;
 import org.junit.jupiter.api.DisplayName;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -15,7 +16,11 @@ class MemberControllerTestHelper extends WebMvcTestBase {
     @MockBean
     protected MemberService memberService;
 
+    @MockBean
+    protected ValidateDuplicateFacade validateDuplicateFacade;
+
     private static final String MEMBER_SIGN_UP_URI = "/member/sign-up";
+    private static final String MEMBER_SIGN_UP_VALIDATE_DUPLICATE_URL = "/member/validate?{target_field}={target_value}";
     protected final SignUpRequest 유효_하지_않은_회원_가입_요청_객체 = new SignUpRequest(
         "",
         "",
@@ -30,5 +35,11 @@ class MemberControllerTestHelper extends WebMvcTestBase {
         return post()
             .url(MEMBER_SIGN_UP_URI)
             .jsonContent(회원_가입_요청_정보);
+    }
+
+    protected Expect 중복_검사_요청(String 중복_검사_항목_명, String 중복_검사_항목) {
+        return get()
+            .url(MEMBER_SIGN_UP_VALIDATE_DUPLICATE_URL, 중복_검사_항목_명, 중복_검사_항목)
+            .expect();
     }
 }

--- a/porko-service/src/test/java/io/porko/member/controller/MemberControllerTestHelper.java
+++ b/porko-service/src/test/java/io/porko/member/controller/MemberControllerTestHelper.java
@@ -1,0 +1,34 @@
+package io.porko.member.controller;
+
+import io.porko.config.base.presentation.RequestBuilder.Expect;
+import io.porko.config.base.presentation.WebMvcTestBase;
+import io.porko.member.controller.model.AddressDto;
+import io.porko.member.controller.model.SignUpRequest;
+import io.porko.member.service.MemberService;
+import org.junit.jupiter.api.DisplayName;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@WebMvcTest(MemberController.class)
+@DisplayName("Controller:Member")
+class MemberControllerTestHelper extends WebMvcTestBase {
+    @MockBean
+    protected MemberService memberService;
+
+    private static final String MEMBER_SIGN_UP_URI = "/member/sign-up";
+    protected final SignUpRequest 유효_하지_않은_회원_가입_요청_객체 = new SignUpRequest(
+        "",
+        "",
+        "",
+        "",
+        "",
+        new AddressDto("", ""),
+        null
+    );
+
+    protected Expect 회원_가입_요청(SignUpRequest 회원_가입_요청_정보) {
+        return post()
+            .url(MEMBER_SIGN_UP_URI)
+            .jsonContent(회원_가입_요청_정보);
+    }
+}

--- a/porko-service/src/test/java/io/porko/member/facade/ValidateDuplicateFacadeTest.java
+++ b/porko-service/src/test/java/io/porko/member/facade/ValidateDuplicateFacadeTest.java
@@ -1,0 +1,66 @@
+package io.porko.member.facade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import io.porko.config.base.business.ServiceTestBase;
+import io.porko.member.controller.model.AvailabilityStatus;
+import io.porko.member.controller.model.ValidateDuplicateRequest;
+import io.porko.member.controller.model.ValidateDuplicateResponse;
+import io.porko.member.exception.MemberErrorCode;
+import io.porko.member.exception.MemberException;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@DisplayName("Facade:ValidateDuplicate")
+class ValidateDuplicateFacadeTest extends ServiceTestBase {
+    private final ValidateDuplicateFacade validateDuplicateFacade;
+
+    public ValidateDuplicateFacadeTest(ValidateDuplicateFacade validateDuplicateFacade) {
+        this.validateDuplicateFacade = validateDuplicateFacade;
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    @DisplayName("중복 검사 요청 타입을 선별하고 각 타입에 적절한 중복 검사 실시 후 결과를 반환한다.")
+    void isDuplicated(final ValidateDuplicateRequest given) {
+        // When
+        ValidateDuplicateResponse actual = validateDuplicateFacade.isDuplicated(given);
+
+        // Then
+        assertThat(actual.isDuplicated()).isFalse();
+        assertThat(actual.availabilityStatus()).isEqualTo(AvailabilityStatus.AVAILABLE);
+    }
+
+    private static Stream<Arguments> isDuplicated() {
+        return Stream.of(
+            Arguments.of(ValidateDuplicateRequest.of("porkoMemberId", null)),
+            Arguments.of(ValidateDuplicateRequest.of(null, "testMember@porko.info"))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    @DisplayName("[예외]중복 여부 검사 요청 값의 형식이 유효하지 않은 경우")
+    void throwMemberException_WhenValidateDuplicateRequest(ValidateDuplicateRequest given) {
+        // When & Then
+        assertThatExceptionOfType(MemberException.class)
+            .isThrownBy(() -> validateDuplicateFacade.isDuplicated(given))
+            .extracting(MemberException::getCode)
+            .isEqualTo(MemberErrorCode.INVALID_VALIDATE_DUPLICATE_TARGET_FORMAT.name())
+        ;
+    }
+
+    private static Stream<Arguments> throwMemberException_WhenValidateDuplicateRequest() {
+        return Stream.of(
+            Arguments.of(ValidateDuplicateRequest.of("", null)),
+            Arguments.of(ValidateDuplicateRequest.of(null, "some email request")),
+            Arguments.of(ValidateDuplicateRequest.of(null, null))
+        );
+    }
+}

--- a/porko-service/src/test/java/io/porko/member/facade/dto/ValidateDuplicateRequestFieldTest.java
+++ b/porko-service/src/test/java/io/porko/member/facade/dto/ValidateDuplicateRequestFieldTest.java
@@ -1,0 +1,49 @@
+package io.porko.member.facade.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.util.AbstractMap;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@DisplayName("Facade:DTO:ValidateDuplicateRequestField")
+class ValidateDuplicateRequestFieldTest {
+    @ParameterizedTest
+    @MethodSource
+    @DisplayName("중복 검사 요청 항목 추출")
+    void create(final AbstractMap.SimpleEntry<String, Object> firstEntry, ValidateDuplicateRequestType expected) {
+        // When
+        ValidateDuplicateRequestField actual = ValidateDuplicateRequestField.of(firstEntry);
+
+        // Then
+        assertThat(actual).hasFieldOrPropertyWithValue("requestType", expected);
+    }
+
+    private static Stream<Arguments> create() {
+        return Stream.of(
+            Arguments.of(
+                new AbstractMap.SimpleEntry<>("memberId", "porkoMemberId"),
+                ValidateDuplicateRequestType.MEMBER_ID
+            ),
+            Arguments.of(new AbstractMap.SimpleEntry<>("email", "porkoMemberId@porko.info"),
+                ValidateDuplicateRequestType.EMAIL
+            )
+        );
+    }
+
+    @Test
+    @DisplayName("[예외]중복 검사 대상 항목이 아닌 경우")
+    void throwException_WhenNotValidateDuplicateTargetField() {
+        // Given
+        AbstractMap.SimpleEntry<String, Object> firstEntry = new AbstractMap.SimpleEntry<>("invalid field", "porkoMemberId");
+
+        // When & Then
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> ValidateDuplicateRequestField.of(firstEntry));
+    }
+}

--- a/porko-service/src/test/java/io/porko/member/facade/dto/ValidateDuplicateRequestTypeTest.java
+++ b/porko-service/src/test/java/io/porko/member/facade/dto/ValidateDuplicateRequestTypeTest.java
@@ -1,0 +1,41 @@
+package io.porko.member.facade.dto;
+
+import static io.porko.config.fixture.FixtureCommon.randomString;
+import static io.porko.member.exception.MemberErrorCode.INVALID_VALIDATE_DUPLICATE_TARGET_FORMAT;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
+import io.porko.member.exception.MemberException;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayName("Facade:DTO:ValidateDuplicateRequestType")
+class ValidateDuplicateRequestTypeTest {
+    @ParameterizedTest
+    @MethodSource
+    @NullAndEmptySource
+    @ValueSource(strings = {" "})
+    @DisplayName("[예외]중복 검사 요청값의 형식이 유효하지 않은 경우")
+    void throwMemberException_GivenInvalidFormatValidateDuplicatedTypeValue(String given) {
+        // When & Then
+        assertThatExceptionOfType(MemberException.class)
+            .isThrownBy(() -> ValidateDuplicateRequestType.MEMBER_ID.validateFormat(given))
+            .extracting(MemberException::getCode)
+            .isEqualTo(INVALID_VALIDATE_DUPLICATE_TARGET_FORMAT.name())
+        ;
+    }
+
+    private static Stream<Arguments> throwMemberException_GivenInvalidFormatValidateDuplicatedTypeValue() {
+        String underLength = randomString().ofMinLength(5).sample();
+        String overLength = randomString().ofMinLength(20).sample();
+
+        return Stream.of(
+            Arguments.of(underLength),
+            Arguments.of(overLength)
+        );
+    }
+}

--- a/porko-service/src/test/java/io/porko/member/repo/MemberRepoTest.java
+++ b/porko-service/src/test/java/io/porko/member/repo/MemberRepoTest.java
@@ -1,0 +1,51 @@
+package io.porko.member.repo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import io.porko.config.base.persistence.JpaTestBase;
+import io.porko.member.domain.Address;
+import io.porko.member.domain.Gender;
+import io.porko.member.domain.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Domain:Member")
+class MemberRepoTest extends JpaTestBase {
+    private final MemberRepo memberRepo;
+
+    public MemberRepoTest(MemberRepo memberRepo) {
+        this.memberRepo = memberRepo;
+    }
+
+    @Test
+    @DisplayName("회원 저장")
+    void save() {
+        // Given
+        Member given = Member.of(
+            "memberId",
+            "password",
+            "name",
+            "email",
+            "01012345678",
+            Address.of("roadName", "detail"),
+            Gender.MALE
+        );
+
+        // When
+        Member actual = memberRepo.save(given);
+
+        // Then
+        assertAll(
+            () -> assertThat(actual.getId())
+                .as("JPA PK 생성 전략에 의한 PK값 부여 여부 검증")
+                .isNotNull(),
+            () -> assertThat(actual.getCreatedAt())
+                .as("JPA AuditingListener에 의한 생성일시 부여 여부 검증")
+                .isNotNull(),
+            () -> assertThat(actual.getUpdatedAt())
+                .as("TestJpaConfiguration의 @EnableJpaAuditing(modifyOnCreate = false)설정에 의해 생성된 데이터의 수정일시 미 부여 여부 검증")
+                .isNull()
+        );
+    }
+}

--- a/porko-service/src/test/java/io/porko/member/repo/MemberRepoTest.java
+++ b/porko-service/src/test/java/io/porko/member/repo/MemberRepoTest.java
@@ -10,7 +10,7 @@ import io.porko.member.domain.Member;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-@DisplayName("Domain:Member")
+@DisplayName("Repo:Member")
 class MemberRepoTest extends JpaTestBase {
     private final MemberRepo memberRepo;
 

--- a/porko-service/src/test/java/io/porko/member/service/MemberServiceTest.java
+++ b/porko-service/src/test/java/io/porko/member/service/MemberServiceTest.java
@@ -1,0 +1,107 @@
+package io.porko.member.service;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import io.porko.config.base.business.ServiceTestBase;
+import io.porko.config.fixture.FixtureCommon;
+import io.porko.member.controller.model.SignUpRequest;
+import io.porko.member.domain.Member;
+import io.porko.member.exception.MemberErrorCode;
+import io.porko.member.exception.MemberException;
+import io.porko.member.repo.MemberRepo;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.AdditionalAnswers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@DisplayName("Service:Member")
+class MemberServiceTest extends ServiceTestBase {
+    @Mock
+    private MemberRepo memberRepo;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    private final SignUpRequest 회원_가입_요청_객체 = FixtureCommon.dtoType().giveMeOne(SignUpRequest.class);
+
+    @Test
+    @DisplayName("회원 생성")
+    void createMember() {
+        // Given
+        회원_생성_의존성_행동_정의(회원_가입_요청_객체);
+
+        // When
+        회원_생성(회원_가입_요청_객체);
+
+        // Then
+        회원_생성_의존성_동작_검증(회원_가입_요청_객체);
+    }
+
+    private void 회원_생성_의존성_행동_정의(SignUpRequest signUpRequest) {
+        given(memberRepo.existsByMemberId(signUpRequest.memberId())).willReturn(false);
+        given(memberRepo.existsByEmail(signUpRequest.email())).willReturn(false);
+        given(memberRepo.save(any(Member.class))).will(AdditionalAnswers.returnsFirstArg());
+    }
+
+    private void 회원_생성(SignUpRequest 회원_가입_요청_객체) {
+        assertDoesNotThrow(() -> memberService.createMember(회원_가입_요청_객체));
+    }
+
+    private void 회원_생성_의존성_동작_검증(SignUpRequest 회원_가입_요청_객체) {
+        verify(memberRepo).existsByMemberId(회원_가입_요청_객체.memberId());
+        verify(memberRepo).existsByEmail(회원_가입_요청_객체.email());
+        verify(passwordEncoder).encode(회원_가입_요청_객체.password());
+        verify(memberRepo).save(any(Member.class));
+    }
+
+    @Test
+    @DisplayName("회원 생성 실패: 중복된 아이디")
+    void throwMemberException_GivenDuplicatedMemberId() {
+        // Given
+        String 중복된_회원_아이디 = 회원_가입_요청_객체.memberId();
+        given(memberRepo.existsByMemberId(중복된_회원_아이디)).willReturn(true);
+
+        // When
+        assertThatExceptionOfType(MemberException.class)
+            .isThrownBy(() -> memberService.createMember(회원_가입_요청_객체))
+            .extracting(MemberException::getCode, MemberException::getMessage)
+            .containsExactly(
+                MemberErrorCode.DUPLICATED_MEMBER_ID.name(),
+                MemberErrorCode.DUPLICATED_MEMBER_ID.getMessage().formatted(중복된_회원_아이디)
+            )
+        ;
+
+        // Then
+        verify(memberRepo).existsByMemberId(중복된_회원_아이디);
+    }
+
+    @Test
+    @DisplayName("회원 생성 실패: 중복된 이메일")
+    void throwMemberException_GivenDuplicatedEmail() {
+        // Given
+        String 중복된_회원_이메일 = 회원_가입_요청_객체.email();
+        given(memberRepo.existsByEmail(중복된_회원_이메일)).willReturn(true);
+
+        // When
+        assertThatExceptionOfType(MemberException.class)
+            .isThrownBy(() -> memberService.createMember(회원_가입_요청_객체))
+            .extracting(MemberException::getCode, MemberException::getMessage)
+            .containsExactly(
+                MemberErrorCode.DUPLICATED_EMAIL.name(),
+                MemberErrorCode.DUPLICATED_EMAIL.getMessage().formatted(중복된_회원_이메일)
+            )
+        ;
+
+        // Then
+        verify(memberRepo).existsByEmail(중복된_회원_이메일);
+    }
+}

--- a/porko-service/src/test/java/io/porko/member/service/MemberServiceTest.java
+++ b/porko-service/src/test/java/io/porko/member/service/MemberServiceTest.java
@@ -64,7 +64,7 @@ class MemberServiceTest extends ServiceTestBase {
     }
 
     @Test
-    @DisplayName("회원 생성 실패: 중복된 아이디")
+    @DisplayName("[예외]회원 생성 실패: 중복된 아이디")
     void throwMemberException_GivenDuplicatedMemberId() {
         // Given
         String 중복된_회원_아이디 = 회원_가입_요청_객체.memberId();
@@ -85,7 +85,7 @@ class MemberServiceTest extends ServiceTestBase {
     }
 
     @Test
-    @DisplayName("회원 생성 실패: 중복된 이메일")
+    @DisplayName("[예외]회원 생성 실패: 중복된 이메일")
     void throwMemberException_GivenDuplicatedEmail() {
         // Given
         String 중복된_회원_이메일 = 회원_가입_요청_객체.email();

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,2 @@
 rootProject.name = "porko"
-include("porko-common")
+include("porko-common", "porko-service")


### PR DESCRIPTION
## #️⃣연관된 이슈

> #1 회원 가입 API 구현

## 📝작업 내용

- [porko 사용자 서비스 기능 제공을 위한 porko-service 모듈 생성](https://github.com/project-porko/porko-service/commit/158cf57e094dd9d879e74638857007cba1080a82)
- [회원 도메인 객체 Entity 변환](https://github.com/project-porko/porko-service/commit/cb59a7cb1a25658a016cf698aa193aa3a3e30860)
- [회원 생성 관련 비지니스 로직 구현](https://github.com/project-porko/porko-service/commit/6c9a1579a75106a7c11e1d0fc290a89131a8d7ed)
- [회원 가입 API 구현](https://github.com/project-porko/porko-service/commit/d69066ef46f967e2c66dd2d7501707c2937534cc)
- [회원 가입 항목 중복 검사 API 구현](https://github.com/project-porko/porko-service/commit/2c5dc874599e1eb6eae8bbe4390d074aa414aa01)