### PR TITLE
fix: 회원 가입 API 실행 중 발생한 data too long for column 에러 수정

### DIFF
--- a/porko-service/src/main/java/io/porko/member/controller/model/signup/AddressDto.java
+++ b/porko-service/src/main/java/io/porko/member/controller/model/signup/AddressDto.java
@@ -1,9 +1,15 @@
 package io.porko.member.controller.model.signup;
 
 import io.porko.member.domain.Address;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record AddressDto(
+    @NotBlank
     String roadName,
+
+    @NotBlank
+    @Size(max = 30)
     String detail
 ) {
     public Address toEntity() {

--- a/porko-service/src/main/java/io/porko/member/controller/model/signup/SignUpRequest.java
+++ b/porko-service/src/main/java/io/porko/member/controller/model/signup/SignUpRequest.java
@@ -28,6 +28,7 @@ public record SignUpRequest(
     @Size(max = 11)
     String phoneNumber,
 
+    @NotNull
     AddressDto address,
 
     @NotNull


### PR DESCRIPTION
현상
- 회원 가입 API TC 실행 중 간헐적으로 Member Entity insert 과정에서 상세 주소 항목인 detail 컬럼에 대한 'data too long for column' 에러 발생

원인
- fixture-monkey를 이용해 회원 가입 요청 객체에 적용된 JSR-380 Annotations을 만족하는 요청 값을 생성하는 과정에서 상세 주소(AddressDto.detail)항목의 JSR-380 Annotation을 이용한 유효성 검증 부 누락으로 인한 오류 발생

해결
- 요구 사항에 따라 상세 주소 항목에는 Null, 빈값, 공백이 아니고 30자 이하의 Text를 입력받도록 @NotBlank, @Size(max=30) JSR-380 Annotations 적용 법정명/도로명 주소와 상세 주소로 이루어진 주소 객체(AddressDto)는 필수 입력 사항이므로, Null이 요청되지 않도록 @NotNull JSR-380 Annotations 적용

---
This close #10 