### PR TITLE
feat: 로그인 API 구현

### DIFF
--- a/porko-common/src/main/java/io/porko/utils/ConvertUtils.java
+++ b/porko-common/src/main/java/io/porko/utils/ConvertUtils.java
@@ -1,11 +1,5 @@
 package io.porko.utils;
 
-import java.lang.reflect.Field;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
-
 public class ConvertUtils {
     public static String convertToConstants(String value) {
         String regex = "([a-z])([A-Z])";
@@ -13,24 +7,5 @@ public class ConvertUtils {
 
         return value.replaceAll(regex, replacement)
             .toUpperCase();
-    }
-
-    public static Map<String, Object> convertToMap(Object obj) {
-        try {
-            if (Objects.isNull(obj)) {
-                return Collections.emptyMap();
-            }
-            Map<String, Object> convertMap = new HashMap<>();
-
-            Field[] fields = obj.getClass().getDeclaredFields();
-
-            for (Field field : fields) {
-                field.setAccessible(true);
-                convertMap.put(field.getName(), field.get(obj));
-            }
-            return convertMap;
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/porko-common/src/test/java/io/porko/config/base/presentation/RequestBuilder.java
+++ b/porko-common/src/test/java/io/porko/config/base/presentation/RequestBuilder.java
@@ -1,5 +1,6 @@
 package io.porko.config.base.presentation;
 
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpMethod.DELETE;
 import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpMethod.POST;
@@ -104,9 +105,25 @@ public class RequestBuilder {
     }
 
     public class EndPoint {
-        public Content url(final String urlInput, final Object... urlVariablesInput) {
+        //        public Content url(final String urlInput, final Object... urlVariablesInput) {
+//            url = urlInput;
+//            urlVariables = Arrays.asList(urlVariablesInput);
+//            return new Content();
+//        }
+        public Header url(final String urlInput, final Object... urlVariablesInput) {
             url = urlInput;
             urlVariables = Arrays.asList(urlVariablesInput);
+            return new Header();
+        }
+    }
+
+    public class Header {
+        public Content authentication(final String token) {
+            headers.put(AUTHORIZATION, "Bearer ".concat(token));
+            return new Content();
+        }
+
+        public Content noAuthentication() {
             return new Content();
         }
     }

--- a/porko-common/src/test/java/io/porko/config/base/presentation/WebMvcTestBase.java
+++ b/porko-common/src/test/java/io/porko/config/base/presentation/WebMvcTestBase.java
@@ -3,14 +3,11 @@ package io.porko.config.base.presentation;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.porko.config.base.TestBase;
-import io.porko.config.security.TestSecurityConfig;
 import jakarta.annotation.Resource;
 import java.io.UnsupportedEncodingException;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
-@Import(TestSecurityConfig.class)
 public abstract class WebMvcTestBase extends TestBase {
     @Resource
     protected MockMvc mockMvc;

--- a/porko-service/build.gradle.kts
+++ b/porko-service/build.gradle.kts
@@ -16,5 +16,6 @@ dependencies {
     runtimeOnly("io.jsonwebtoken:jjwt-impl:${DependencyVersions.JJWT_VERSION}")
 
     testRuntimeOnly("com.h2database:h2")
+    testImplementation("org.springframework.security:spring-security-test")
     testImplementation(testSourceSet)
 }

--- a/porko-service/build.gradle.kts
+++ b/porko-service/build.gradle.kts
@@ -1,11 +1,19 @@
 val testSourceSet: SourceSetOutput = project(":porko-common").sourceSets["test"].output
 
+object DependencyVersions {
+    const val JJWT_VERSION = "0.11.5"
+}
+
 dependencies {
     implementation(project(":porko-common"))
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-validation")
+
+    implementation("io.jsonwebtoken:jjwt-api:${DependencyVersions.JJWT_VERSION}")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:${DependencyVersions.JJWT_VERSION}")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:${DependencyVersions.JJWT_VERSION}")
 
     testRuntimeOnly("com.h2database:h2")
     testImplementation(testSourceSet)

--- a/porko-service/src/main/java/io/porko/PorkoServiceApp.java
+++ b/porko-service/src/main/java/io/porko/PorkoServiceApp.java
@@ -1,9 +1,12 @@
 package io.porko;
 
+import io.porko.auth.config.jwt.JwtProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
+@EnableConfigurationProperties(JwtProperties.class)
 public class PorkoServiceApp {
     public static void main(String[] args) {
         System.setProperty("spring.config.name", "application, application-service");

--- a/porko-service/src/main/java/io/porko/auth/config/PasswordEncoderConfig.java
+++ b/porko-service/src/main/java/io/porko/auth/config/PasswordEncoderConfig.java
@@ -1,4 +1,4 @@
-package io.porko.config.security;
+package io.porko.auth.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/porko-service/src/main/java/io/porko/auth/config/SecurityConfig.java
+++ b/porko-service/src/main/java/io/porko/auth/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package io.porko.auth.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.porko.auth.config.jwt.JwtProperties;
 import io.porko.auth.filter.TokenVerifyFilter;
 import io.porko.auth.service.AuthService;
@@ -19,6 +20,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
     private final AuthService authService;
     private final JwtProperties jwtProperties;
+    private final ObjectMapper objectMapper;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -37,6 +39,10 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.POST, "/member/sign-up", "/login").permitAll()
                 .requestMatchers(HttpMethod.GET, "/member/validate").permitAll()
                 .anyRequest().authenticated()
+            )
+            // [TODO:Feature] : 403 권한 없음 예외 처리를 위한 AccessDeniedHandler 구현 및 등록
+            .exceptionHandling(exceptionHandlingConfigurer ->
+                exceptionHandlingConfigurer.authenticationEntryPoint(new UnauthorizedEntryPoint(objectMapper))
             )
             .addFilterBefore(
                 new TokenVerifyFilter(authService, jwtProperties),

--- a/porko-service/src/main/java/io/porko/auth/config/SecurityConfig.java
+++ b/porko-service/src/main/java/io/porko/auth/config/SecurityConfig.java
@@ -1,4 +1,4 @@
-package io.porko.config.security;
+package io.porko.auth.config;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;

--- a/porko-service/src/main/java/io/porko/auth/config/SecurityConfig.java
+++ b/porko-service/src/main/java/io/porko/auth/config/SecurityConfig.java
@@ -1,17 +1,25 @@
 package io.porko.auth.config;
 
+import io.porko.auth.config.jwt.JwtProperties;
+import io.porko.auth.filter.TokenVerifyFilter;
+import io.porko.auth.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @RequiredArgsConstructor
 public class SecurityConfig {
+    private final AuthService authService;
+    private final JwtProperties jwtProperties;
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
@@ -24,8 +32,15 @@ public class SecurityConfig {
             .sessionManagement(sessionManagementConfigurer -> sessionManagementConfigurer
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             )
+            // [TODO:Refactor] endpoint, roles에 따른 인가 정책 가독성 개선을 위한 AuthenticationEndpointByRoles 적용
             .authorizeHttpRequests(auth -> auth
-                .anyRequest().permitAll()
+                .requestMatchers(HttpMethod.POST, "/member/sign-up", "/login").permitAll()
+                .requestMatchers(HttpMethod.GET, "/member/validate").permitAll()
+                .anyRequest().authenticated()
+            )
+            .addFilterBefore(
+                new TokenVerifyFilter(authService, jwtProperties),
+                UsernamePasswordAuthenticationFilter.class
             )
             .build();
     }

--- a/porko-service/src/main/java/io/porko/auth/config/UnauthorizedEntryPoint.java
+++ b/porko-service/src/main/java/io/porko/auth/config/UnauthorizedEntryPoint.java
@@ -1,0 +1,33 @@
+package io.porko.auth.config;
+
+import static io.porko.auth.filter.TokenVerifyFilter.EXCEPTION;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.porko.auth.exception.AuthException;
+import io.porko.exception.response.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+// TODO[#1]: TokenVerifyFilter에서 throw된 Exception을 이용한 예외 응답 처리
+// TODO[#2]: EntryPoint을 이용한 예외 응답 처리 시, 한글 깨짐 방지를 위해 Deprecated된 APPLICATION_JSON_UTF8_VALUE 적용 부 수정
+@RequiredArgsConstructor
+public class UnauthorizedEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
+        throws IOException {
+        AuthException exception = (AuthException) request.getAttribute(EXCEPTION);
+        ErrorResponse errorResponse = ErrorResponse.businessErrorOf(request, exception);
+
+        response.setContentType(MediaType.APPLICATION_JSON_UTF8_VALUE);
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/porko-service/src/main/java/io/porko/auth/config/jwt/JwtProperties.java
+++ b/porko-service/src/main/java/io/porko/auth/config/jwt/JwtProperties.java
@@ -1,0 +1,13 @@
+package io.porko.auth.config.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jwt")
+public record JwtProperties(
+    String issuer,
+    String secretKey,
+    String audience,
+    int expirePeriod
+) {
+
+}

--- a/porko-service/src/main/java/io/porko/auth/controller/AuthController.java
+++ b/porko-service/src/main/java/io/porko/auth/controller/AuthController.java
@@ -1,0 +1,29 @@
+package io.porko.auth.controller;
+
+import io.porko.auth.controller.model.LoginRequest;
+import io.porko.auth.controller.model.LoginResponse;
+import io.porko.auth.service.AuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping(
+    consumes = MediaType.APPLICATION_JSON_VALUE,
+    produces = MediaType.APPLICATION_JSON_VALUE
+)
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("login")
+    ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest loginRequest) {
+        LoginResponse loginResponse = authService.authenticate(loginRequest);
+        return ResponseEntity.ok(loginResponse);
+    }
+}

--- a/porko-service/src/main/java/io/porko/auth/controller/model/LoginRequest.java
+++ b/porko-service/src/main/java/io/porko/auth/controller/model/LoginRequest.java
@@ -1,0 +1,14 @@
+package io.porko.auth.controller.model;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record LoginRequest(
+    @NotBlank
+    @Size(min = 6, max = 20)
+    String memberId,
+
+    @NotBlank
+    String password
+) {
+}

--- a/porko-service/src/main/java/io/porko/auth/controller/model/LoginResponse.java
+++ b/porko-service/src/main/java/io/porko/auth/controller/model/LoginResponse.java
@@ -1,0 +1,14 @@
+package io.porko.auth.controller.model;
+
+import java.time.LocalDateTime;
+
+public record LoginResponse(
+    Long id,
+    String memberId,
+    String accessToken,
+    LocalDateTime loggedInAt
+) {
+    public static LoginResponse of(PorkoPrincipal porkoPrincipal, String accessToken) {
+        return new LoginResponse(porkoPrincipal.getId(), porkoPrincipal.getUsername(), accessToken, LocalDateTime.now());
+    }
+}

--- a/porko-service/src/main/java/io/porko/auth/controller/model/PorkoPrincipal.java
+++ b/porko-service/src/main/java/io/porko/auth/controller/model/PorkoPrincipal.java
@@ -1,0 +1,19 @@
+package io.porko.auth.controller.model;
+
+import java.util.Collections;
+import lombok.Getter;
+import org.springframework.security.core.userdetails.User;
+
+@Getter
+public class PorkoPrincipal extends User {
+    private Long id;
+
+    private PorkoPrincipal(Long id, String memberId) {
+        super(memberId, "", Collections.emptySet());
+        this.id = id;
+    }
+
+    public static PorkoPrincipal of(Long id, String memberId) {
+        return new PorkoPrincipal(id, memberId);
+    }
+}

--- a/porko-service/src/main/java/io/porko/auth/controller/model/PorkoPrincipal.java
+++ b/porko-service/src/main/java/io/porko/auth/controller/model/PorkoPrincipal.java
@@ -6,7 +6,7 @@ import org.springframework.security.core.userdetails.User;
 
 @Getter
 public class PorkoPrincipal extends User {
-    private Long id;
+    private final Long id;
 
     private PorkoPrincipal(Long id, String memberId) {
         super(memberId, "", Collections.emptySet());

--- a/porko-service/src/main/java/io/porko/auth/domain/TokenProvider.java
+++ b/porko-service/src/main/java/io/porko/auth/domain/TokenProvider.java
@@ -1,0 +1,41 @@
+package io.porko.auth.domain;
+
+import static io.porko.auth.utils.SigningUtils.getSigningKey;
+
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.porko.auth.config.jwt.JwtProperties;
+import io.porko.auth.controller.model.PorkoPrincipal;
+import java.util.Calendar;
+import java.util.Date;
+
+public class TokenProvider {
+    public static final String ID = "id";
+    public static final String USERNAME = "username";
+
+    public static String generate(PorkoPrincipal porkoPrincipal, JwtProperties jwtProperties, TokenType tokenType) {
+        long currentTimeMillis = System.currentTimeMillis();
+        Date issuedAt = new Date(currentTimeMillis);
+        Date expiration = addMinute(issuedAt, jwtProperties.expirePeriod());
+
+        return Jwts.builder()
+            .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+            .setIssuer(jwtProperties.issuer())
+            .setSubject(tokenType.name())
+            .setAudience(jwtProperties.audience())
+            .setIssuedAt(issuedAt)
+            .setExpiration(expiration)
+            .claim(ID, porkoPrincipal.getId())
+            .claim(USERNAME, porkoPrincipal.getUsername())
+            .signWith(getSigningKey(jwtProperties.secretKey()), SignatureAlgorithm.HS256)
+            .compact();
+    }
+
+    public static Date addMinute(Date target, int terms) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(target);
+        calendar.add(Calendar.MINUTE, terms);
+        return calendar.getTime();
+    }
+}

--- a/porko-service/src/main/java/io/porko/auth/domain/TokenResolver.java
+++ b/porko-service/src/main/java/io/porko/auth/domain/TokenResolver.java
@@ -1,0 +1,59 @@
+package io.porko.auth.domain;
+
+import static io.porko.auth.domain.TokenProvider.ID;
+import static io.porko.auth.domain.TokenProvider.USERNAME;
+import static io.porko.auth.utils.SigningUtils.getSigningKey;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.io.DecodingException;
+import io.jsonwebtoken.security.SignatureException;
+import io.jsonwebtoken.security.WeakKeyException;
+import io.porko.auth.config.jwt.JwtProperties;
+import io.porko.auth.controller.model.PorkoPrincipal;
+import io.porko.auth.exception.AuthErrorCode;
+import io.porko.auth.exception.AuthException;
+
+public class TokenResolver {
+    public static PorkoPrincipal resolve(String token, JwtProperties jwtProperties) {
+        Claims claims = extractClaims(token, jwtProperties);
+        return PorkoPrincipal.of(
+            claims.get(ID, Long.class),
+            claims.get(USERNAME, String.class)
+        );
+    }
+
+    private static Claims extractClaims(String token, JwtProperties jwtProperties) {
+        Claims claims = extractClaims(token, jwtProperties.secretKey());
+        validateAudience(claims, jwtProperties.audience());
+        return claims;
+    }
+
+    private static void validateAudience(Claims claims, String audience) {
+        if (isNotValidAudience(claims.getAudience(), audience)) {
+            throw new AuthException(AuthErrorCode.UNSUPPORTED_AUDIENCE);
+        }
+    }
+
+    private static boolean isNotValidAudience(String tokenAudience, String propertiesAudience) {
+        return !tokenAudience.equals(propertiesAudience);
+    }
+
+    private static Claims extractClaims(String token, String secretKey) {
+        try {
+            return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey(secretKey))
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        } catch (DecodingException | WeakKeyException | SignatureException | NullPointerException signatureException) {
+            throw new AuthException(AuthErrorCode.INVALID_SIGNATURE);
+        } catch (MalformedJwtException malformedJwtException) {
+            throw new AuthException(AuthErrorCode.INVALID_TOKEN_FORMAT);
+        } catch (ExpiredJwtException expiredJwtException) {
+            throw new AuthException(AuthErrorCode.EXPIRED_TOKEN);
+        }
+    }
+}

--- a/porko-service/src/main/java/io/porko/auth/domain/TokenType.java
+++ b/porko-service/src/main/java/io/porko/auth/domain/TokenType.java
@@ -1,0 +1,5 @@
+package io.porko.auth.domain;
+
+public enum TokenType {
+    ACCESS_TOKEN, REFRESH_TOKEN
+}

--- a/porko-service/src/main/java/io/porko/auth/exception/AuthErrorCode.java
+++ b/porko-service/src/main/java/io/porko/auth/exception/AuthErrorCode.java
@@ -1,0 +1,28 @@
+package io.porko.auth.exception;
+
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum AuthErrorCode {
+    BAD_CREDENTIALS(UNAUTHORIZED, "사용자 정보가 잘못 되었습니다."),
+    INVALID_SIGNATURE(UNAUTHORIZED, "서명 정보가 잘못 되었습니다."),
+    EXPIRED_TOKEN(UNAUTHORIZED, "토큰 유효기간이 만료되었습니다."),
+    INVALID_TOKEN_FORMAT(UNAUTHORIZED, "토큰 형식이 올바르지 않습니다."),
+    UNSUPPORTED_AUDIENCE(UNAUTHORIZED, "지원하지 않는 사용자 입니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+
+    AuthErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public String formattingErrorMessage(Object... objects) {
+        return getMessage().formatted(objects);
+    }
+}

--- a/porko-service/src/main/java/io/porko/auth/exception/AuthException.java
+++ b/porko-service/src/main/java/io/porko/auth/exception/AuthException.java
@@ -1,0 +1,16 @@
+package io.porko.auth.exception;
+
+import io.porko.exception.BusinessException;
+
+public class AuthException extends BusinessException {
+    private AuthErrorCode errorCode;
+    private String message;
+
+    public AuthException(AuthErrorCode errorCode) {
+        super(
+            errorCode.getStatus(),
+            errorCode.name(),
+            errorCode.getMessage()
+        );
+    }
+}

--- a/porko-service/src/main/java/io/porko/auth/filter/TokenVerifyFilter.java
+++ b/porko-service/src/main/java/io/porko/auth/filter/TokenVerifyFilter.java
@@ -1,0 +1,78 @@
+package io.porko.auth.filter;
+
+import static io.porko.auth.domain.TokenResolver.resolve;
+
+import io.porko.auth.config.jwt.JwtProperties;
+import io.porko.auth.controller.model.PorkoPrincipal;
+import io.porko.auth.exception.AuthErrorCode;
+import io.porko.auth.exception.AuthException;
+import io.porko.auth.service.AuthService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@RequiredArgsConstructor
+public class TokenVerifyFilter extends OncePerRequestFilter {
+    public static final String BEARER_PREFIX = "Bearer ";
+    public static final String EXCEPTION = "exception";
+
+    private final AuthService authService;
+    private final JwtProperties jwtProperties;
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain chain
+    ) throws ServletException, IOException {
+        try {
+            final String authorizationToken = extractAuthorizationToken(request);
+            PorkoPrincipal porkoPrincipal = resolve(authorizationToken, jwtProperties);
+            verifyPrincipal(porkoPrincipal);
+            processRegisterAuthentication(porkoPrincipal, request);
+        } catch (AuthException e) {
+            request.setAttribute(EXCEPTION, e);
+        }
+        chain.doFilter(request, response);
+    }
+
+    private String extractAuthorizationToken(HttpServletRequest request) {
+        final String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (isNotExistAuthorizationToken(authorizationHeader)) {
+            throw new AuthException(AuthErrorCode.BAD_CREDENTIALS);
+        }
+        return extractToken(authorizationHeader);
+    }
+
+    private boolean isNotExistAuthorizationToken(String header) {
+        return header == null || !header.startsWith(BEARER_PREFIX);
+    }
+
+    private static String extractToken(String header) {
+        return header.split(" ")[1].trim();
+    }
+
+    private void verifyPrincipal(PorkoPrincipal porkoPrincipal) {
+        authService.loadUserByUsername(porkoPrincipal.getUsername());
+    }
+
+    private void processRegisterAuthentication(PorkoPrincipal porkoPrincipal, HttpServletRequest request) {
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+            porkoPrincipal,
+            null,
+            porkoPrincipal.getAuthorities()
+        );
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+    }
+}

--- a/porko-service/src/main/java/io/porko/auth/service/AuthService.java
+++ b/porko-service/src/main/java/io/porko/auth/service/AuthService.java
@@ -1,0 +1,48 @@
+package io.porko.auth.service;
+
+import static io.porko.auth.exception.AuthErrorCode.BAD_CREDENTIALS;
+
+import io.porko.auth.controller.model.LoginRequest;
+import io.porko.auth.controller.model.LoginResponse;
+import io.porko.auth.controller.model.PorkoPrincipal;
+import io.porko.auth.exception.AuthException;
+import io.porko.member.domain.Member;
+import io.porko.member.repo.MemberRepo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AuthService {
+    private final MemberRepo memberRepo;
+    private final PasswordEncoder passwordEncoder;
+    private final TokenService tokenService;
+
+    public LoginResponse authenticate(LoginRequest loginRequest) {
+        PorkoPrincipal porkoPrincipal = verifyMember(loginRequest);
+        String accessToken = tokenService.issueAccessToken(porkoPrincipal);
+
+        return LoginResponse.of(porkoPrincipal, accessToken);
+    }
+
+    private PorkoPrincipal verifyMember(LoginRequest loginRequest) {
+        Member member = loadUserByUsername(loginRequest.memberId());
+        checkPasswordIsMatched(loginRequest.password(), member.getPassword());
+
+        return PorkoPrincipal.of(member.getId(), member.getMemberId());
+    }
+
+    public Member loadUserByUsername(String memberId) {
+        return memberRepo.findByMemberId(memberId)
+            .orElseThrow(() -> new AuthException(BAD_CREDENTIALS));
+    }
+
+    private void checkPasswordIsMatched(String rawPassword, String encodedPassword) {
+        if (!passwordEncoder.matches(rawPassword, encodedPassword)) {
+            throw new AuthException(BAD_CREDENTIALS);
+        }
+    }
+}

--- a/porko-service/src/main/java/io/porko/auth/service/TokenService.java
+++ b/porko-service/src/main/java/io/porko/auth/service/TokenService.java
@@ -1,0 +1,18 @@
+package io.porko.auth.service;
+
+import io.porko.auth.config.jwt.JwtProperties;
+import io.porko.auth.controller.model.PorkoPrincipal;
+import io.porko.auth.domain.TokenType;
+import io.porko.auth.domain.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+    private final JwtProperties jwtProperties;
+
+    public String issueAccessToken(PorkoPrincipal porkoPrincipal) {
+        return TokenProvider.generate(porkoPrincipal, jwtProperties, TokenType.ACCESS_TOKEN);
+    }
+}

--- a/porko-service/src/main/java/io/porko/auth/utils/SigningUtils.java
+++ b/porko-service/src/main/java/io/porko/auth/utils/SigningUtils.java
@@ -1,0 +1,16 @@
+package io.porko.auth.utils;
+
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Base64;
+
+public class SigningUtils {
+    public static Key getSigningKey(String signingKey) {
+        String encodedSigningKey = Base64.getEncoder()
+            .withoutPadding()
+            .encodeToString(signingKey.getBytes());
+        byte[] keyBytes = encodedSigningKey.getBytes(StandardCharsets.UTF_8);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+}

--- a/porko-service/src/main/resources/application-test.yml
+++ b/porko-service/src/main/resources/application-test.yml
@@ -1,0 +1,5 @@
+jwt:
+  issuer: porko.info
+  secret-key: porko-service-test-secret-key
+  expire-period: 10
+  audience: porko-service

--- a/porko-service/src/test/java/io/porko/auth/controller/AuthControllerTest.java
+++ b/porko-service/src/test/java/io/porko/auth/controller/AuthControllerTest.java
@@ -1,0 +1,92 @@
+package io.porko.auth.controller;
+
+import static io.porko.auth.exception.AuthErrorCode.BAD_CREDENTIALS;
+import static io.porko.config.security.TestSecurityConfig.TEST_PORKO_MEMBER_ID;
+import static io.porko.config.security.TestSecurityConfig.testPorkoPrincipal;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import io.porko.auth.config.SecurityConfig;
+import io.porko.auth.config.jwt.JwtProperties;
+import io.porko.auth.controller.model.LoginRequest;
+import io.porko.auth.controller.model.LoginResponse;
+import io.porko.auth.exception.AuthException;
+import io.porko.auth.service.AuthService;
+import io.porko.config.base.presentation.RequestBuilder.Expect;
+import io.porko.config.base.presentation.WebMvcTestBase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+
+@WebMvcTest(AuthController.class)
+@DisplayName("Controller:Auth")
+@Import(SecurityConfig.class)
+class AuthControllerTest extends WebMvcTestBase {
+    @MockBean
+    private AuthService authService;
+
+    @MockBean
+    JwtProperties jwtProperties;
+
+    private static final String LOGIN_URI = "/login";
+    private static final LoginRequest loginRequest = new LoginRequest(TEST_PORKO_MEMBER_ID, "password");
+
+    @Test
+    @DisplayName("[로그인][POST:200]")
+    void login() throws Exception {
+        // Given
+        given(authService.authenticate(loginRequest))
+            .willReturn(LoginResponse.of(testPorkoPrincipal, "access token"));
+
+        // When & Then
+        로그인_요청().ok();
+        verify(authService).authenticate(loginRequest);
+    }
+
+    @Test
+    @DisplayName("[로그인][POST:400]요청값이 올바르지 않은 경우")
+    void throwAuthException_WhenInvalidRequest() throws Exception {
+        // Given
+        LoginRequest invalidLoginRequest = new LoginRequest("", "");
+
+        // When & Then
+        post()
+            .url(LOGIN_URI)
+            .noAuthentication()
+            .jsonContent(invalidLoginRequest)
+            .badRequest();
+    }
+
+    @Test
+    @DisplayName("[로그인][POST:401]사용자 정보가 존재하지 않는 경우")
+    void throwAuthException_WhenMemberNotExist() throws Exception {
+        // Given
+        given(authService.authenticate(loginRequest))
+            .willThrow(new AuthException(BAD_CREDENTIALS));
+
+        // When & Then
+        로그인_요청().unAuthorized();
+        verify(authService).authenticate(loginRequest);
+    }
+
+    @Test
+    @DisplayName("[로그인][POST:401]비밀번호가 일치하지 않는 경우")
+    void throwAuthException_WhenNotMatchedPassword() throws Exception {
+        // Given
+        given(authService.authenticate(loginRequest))
+            .willThrow(new AuthException(BAD_CREDENTIALS));
+
+        // When & Then
+        로그인_요청().unAuthorized();
+        verify(authService).authenticate(loginRequest);
+    }
+
+    private Expect 로그인_요청() {
+        return post()
+            .url(LOGIN_URI)
+            .noAuthentication()
+            .jsonContent(AuthControllerTest.loginRequest);
+    }
+}

--- a/porko-service/src/test/java/io/porko/auth/domain/TokenProviderTest.java
+++ b/porko-service/src/test/java/io/porko/auth/domain/TokenProviderTest.java
@@ -1,0 +1,67 @@
+package io.porko.auth.domain;
+
+import static io.porko.auth.domain.TokenProvider.addMinute;
+import static io.porko.config.security.TestSecurityConfig.testPorkoPrincipal;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwsHeader;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.WeakKeyException;
+import io.porko.auth.config.jwt.JwtProperties;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@DisplayName("Domain:TokenProvider")
+class TokenProviderTest extends TokenTestHelper {
+    @Test
+    @DisplayName("Access Token 생성")
+    void generate() {
+        // When
+        String actual = TokenProvider.generate(testPorkoPrincipal, testJwtProperties, TokenType.ACCESS_TOKEN);
+
+        // Then
+        Jws<Claims> claimsJws = resolve(actual, BASE_64_ENCODED_TEST_SECRET_KEY);
+        Claims claims = claimsJws.getBody();
+        JwsHeader header = claimsJws.getHeader();
+
+        assertAll(
+            () -> assertThat(header.getType()).as("JWT 토큰 타입").isEqualTo(Header.JWT_TYPE),
+            () -> assertThat(header.getAlgorithm()).as("HS 256 해싱 알고리즘").isEqualTo(SignatureAlgorithm.HS256.name()),
+            () -> assertThat(claims.getIssuer()).as("발급 주체").isEqualTo(testJwtProperties.issuer()),
+            () -> assertThat(claims.getAudience()).as("발급 대상").isEqualTo(testJwtProperties.audience()),
+            () -> assertThat(claims.getSubject()).as("발급 목적").isEqualTo(TokenType.ACCESS_TOKEN.name()),
+            () -> assertThat(claims.get("id", Long.class)).isEqualTo(testPorkoPrincipal.getId()),
+            () -> assertThat(claims.get("username", String.class)).isEqualTo(testPorkoPrincipal.getUsername()),
+            () -> assertThat(claims.getExpiration()).as("만료 일시 : 발급 일자로부터 10분 후").isEqualTo(addMinute(claims.getIssuedAt(), 10))
+        );
+    }
+
+    @ParameterizedTest(name = "[{index}]{1}:{0}")
+    @MethodSource
+    @DisplayName("[예외]Signature 값이 올바르지 않은 경우")
+    void throwAuthenticationException_WhenInvalidSigningKey(final String signingKey, final String description) {
+        // Given
+        JwtProperties jwtProperties = new JwtProperties(ISSUER, signingKey, AUDIENCE, EXPIRE_PERIOD_MINUTES.intValue());
+
+        // When & Then
+        assertThatExceptionOfType(WeakKeyException.class)
+            .isThrownBy(() -> TokenProvider.generate(testPorkoPrincipal, jwtProperties, TokenType.ACCESS_TOKEN))
+        ;
+    }
+
+    private static Stream<Arguments> throwAuthenticationException_WhenInvalidSigningKey() {
+        return Stream.of(
+            Arguments.of("invalid encoded key", "Base64 signing key가 아닌 경우"),
+            Arguments.of("invalid weak key", "Signing key 길이가 올바르지 않은 경우")
+        );
+    }
+}

--- a/porko-service/src/test/java/io/porko/auth/domain/TokenResolverTest.java
+++ b/porko-service/src/test/java/io/porko/auth/domain/TokenResolverTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 @DisplayName("Domain:TokenResolver")
 class TokenResolverTest extends TokenTestHelper {
-    private String token = TokenProvider.generate(testPorkoPrincipal, testJwtProperties, TokenType.ACCESS_TOKEN);
+    private final String token = TokenProvider.generate(testPorkoPrincipal, testJwtProperties, TokenType.ACCESS_TOKEN);
 
     @Test
     @DisplayName("토큰 검증")

--- a/porko-service/src/test/java/io/porko/auth/domain/TokenResolverTest.java
+++ b/porko-service/src/test/java/io/porko/auth/domain/TokenResolverTest.java
@@ -1,0 +1,85 @@
+package io.porko.auth.domain;
+
+import static io.porko.config.security.TestSecurityConfig.testPorkoPrincipal;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
+import io.porko.auth.config.jwt.JwtProperties;
+import io.porko.auth.controller.model.PorkoPrincipal;
+import io.porko.auth.exception.AuthErrorCode;
+import io.porko.auth.exception.AuthException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayName("Domain:TokenResolver")
+class TokenResolverTest extends TokenTestHelper {
+    private String token = TokenProvider.generate(testPorkoPrincipal, testJwtProperties, TokenType.ACCESS_TOKEN);
+
+    @Test
+    @DisplayName("토큰 검증")
+    void resolve() {
+        // When
+        PorkoPrincipal actual = TokenResolver.resolve(token, testJwtProperties);
+
+        // Then
+        assertThat(actual.getId()).isEqualTo(testPorkoPrincipal.getId());
+        assertThat(actual.getUsername()).isEqualTo(testPorkoPrincipal.getUsername());
+    }
+
+    @Test
+    @DisplayName("[예외]Signature가 일치 하지 않는 경우")
+    void throwAuthException_WhenNotMatchedSigningKey() {
+        // given
+        final String notMatchedSecretKey = "not-matched-generated-token-secret-key";
+        JwtProperties jwtProperties = generateTestJwtProperties(notMatchedSecretKey);
+        String generate = TokenProvider.generate(testPorkoPrincipal, jwtProperties, TokenType.ACCESS_TOKEN);
+
+        // When & Then
+        assertThatExceptionOfType(AuthException.class)
+            .isThrownBy(() -> TokenResolver.resolve(generate, testJwtProperties))
+            .extracting(AuthException::getCode).isEqualTo(AuthErrorCode.INVALID_SIGNATURE.name())
+        ;
+    }
+
+    @Test
+    @DisplayName("[예외]토큰이 만료된 경우")
+    void throwAuthException_WhenTokenExpired() {
+        // Given
+        JwtProperties jwtProperties = new JwtProperties(ISSUER, BASE_64_ENCODED_TEST_SECRET_KEY, AUDIENCE, 0);
+        String token = TokenProvider.generate(testPorkoPrincipal, jwtProperties, TokenType.ACCESS_TOKEN);
+
+        // When & Then
+        assertThatExceptionOfType(AuthException.class)
+            .isThrownBy(() -> TokenResolver.resolve(token, testJwtProperties))
+            .extracting(AuthException::getCode).isEqualTo(AuthErrorCode.EXPIRED_TOKEN.name())
+        ;
+    }
+
+    @Test
+    @DisplayName("[예외]지원하지 않는 토큰 발급 대상자인 경우")
+    void throwAuthException_WhenUnsupportedAudience() {
+        // Given
+        JwtProperties jwtProperties = new JwtProperties(ISSUER, BASE_64_ENCODED_TEST_SECRET_KEY, "invalid audience",
+            EXPIRE_PERIOD_MINUTES.intValue());
+        String token = TokenProvider.generate(testPorkoPrincipal, jwtProperties, TokenType.ACCESS_TOKEN);
+
+        // When & Then
+        assertThatExceptionOfType(AuthException.class)
+            .isThrownBy(() -> TokenResolver.resolve(token, testJwtProperties))
+            .extracting(AuthException::getCode).isEqualTo(AuthErrorCode.UNSUPPORTED_AUDIENCE.name())
+        ;
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"aaa", "header.payload.signature"})
+    @DisplayName("[예외]JWT 토큰 형식이 올바르지 않은 경우")
+    void throwAuthException_WhenInvalidTokenFormat(final String given) {
+        // When & Then
+        assertThatExceptionOfType(AuthException.class)
+            .isThrownBy(() -> TokenResolver.resolve(given, testJwtProperties))
+            .extracting(AuthException::getCode).isEqualTo(AuthErrorCode.INVALID_TOKEN_FORMAT.name())
+        ;
+    }
+}

--- a/porko-service/src/test/java/io/porko/auth/domain/TokenTestHelper.java
+++ b/porko-service/src/test/java/io/porko/auth/domain/TokenTestHelper.java
@@ -1,0 +1,39 @@
+package io.porko.auth.domain;
+
+import static io.porko.auth.utils.SigningUtils.getSigningKey;
+import static java.math.BigInteger.TEN;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.porko.auth.config.jwt.JwtProperties;
+import java.util.Base64;
+import java.util.concurrent.TimeUnit;
+
+public class TokenTestHelper {
+    protected static final String ISSUER = "test.porko.info";
+    protected static final String AUDIENCE = "test-porko-client";
+    protected static final Long EXPIRE_PERIOD_MINUTES = TimeUnit.MINUTES.toMinutes(TEN.longValue());
+    private static final String TEST_SECRET_KEY = "test-porko-service-secret-key";
+    protected static final String BASE_64_ENCODED_TEST_SECRET_KEY = encodeSecretKey(TEST_SECRET_KEY);
+
+    public static JwtProperties testJwtProperties = new JwtProperties(ISSUER, BASE_64_ENCODED_TEST_SECRET_KEY, AUDIENCE,
+        EXPIRE_PERIOD_MINUTES.intValue());
+
+    public JwtProperties generateTestJwtProperties(String secretKey) {
+        return new JwtProperties(ISSUER, encodeSecretKey(secretKey), AUDIENCE, EXPIRE_PERIOD_MINUTES.intValue());
+    }
+
+    private static String encodeSecretKey(String secretKey) {
+        return Base64.getEncoder()
+            .withoutPadding()
+            .encodeToString(secretKey.getBytes());
+    }
+
+    protected static Jws<Claims> resolve(String token, String secretKey) {
+        return Jwts.parserBuilder()
+            .setSigningKey(getSigningKey(secretKey))
+            .build()
+            .parseClaimsJws(token);
+    }
+}

--- a/porko-service/src/test/java/io/porko/config/security/TestSecurityConfig.java
+++ b/porko-service/src/test/java/io/porko/config/security/TestSecurityConfig.java
@@ -1,8 +1,8 @@
 package io.porko.config.security;
 
+import io.porko.auth.config.SecurityConfig;
 import org.springframework.context.annotation.Import;
 
-// TODO: Mocking을 통해 인증된 사용자 정보 제공
 @Import(SecurityConfig.class)
 public class TestSecurityConfig {
 }

--- a/porko-service/src/test/java/io/porko/config/security/TestSecurityConfig.java
+++ b/porko-service/src/test/java/io/porko/config/security/TestSecurityConfig.java
@@ -1,8 +1,54 @@
 package io.porko.config.security;
 
+import static io.porko.auth.domain.TokenProvider.ID;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
 import io.porko.auth.config.SecurityConfig;
+import io.porko.auth.config.jwt.JwtProperties;
+import io.porko.auth.controller.model.PorkoPrincipal;
+import io.porko.auth.service.AuthService;
+import io.porko.member.domain.Address;
+import io.porko.member.domain.Gender;
+import io.porko.member.domain.Member;
+import jakarta.annotation.Resource;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.test.context.event.annotation.BeforeTestMethod;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @Import(SecurityConfig.class)
 public class TestSecurityConfig {
+    @MockBean
+    private AuthService authService;
+
+    @MockBean
+    private InMemoryUserDetailsManager inMemoryUserDetailsManager;
+
+    @Resource
+    public JwtProperties jwtProperties;
+
+    @BeforeTestMethod
+    public void setUp() {
+        ReflectionTestUtils.setField(testMember, ID, TEST_PORKO_ID);
+
+        given(inMemoryUserDetailsManager.loadUserByUsername(anyString()))
+            .willReturn(testPorkoPrincipal);
+    }
+
+    public static final Long TEST_PORKO_ID = 1L;
+    public static final String TEST_PORKO_MEMBER_ID = "testPorkoMemberId";
+
+    public static final PorkoPrincipal testPorkoPrincipal = PorkoPrincipal.of(TEST_PORKO_ID, TEST_PORKO_MEMBER_ID);
+
+    public static final Member testMember = Member.of(
+        TEST_PORKO_MEMBER_ID,
+        "testPorkoMemberPassword",
+        "testPorkorer",
+        "testPorkorer@porko.info",
+        "01011112222",
+        Address.of("서울시 서초구", "강남"),
+        Gender.MALE
+    );
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #9 로그인 API 구현 : Spring Security + JWT
> #13 인증된 사용자정보 주입을 위한 CustomAnnotation @LoginMember 구현

## 📝작업 내용
- [인증 관련 설정 파일 이관](https://github.com/project-porko/porko-service/commit/2e430d73d838661fc323f338293aa4e4dc93c8f5)
- [JWT 인증 토큰 발급 및 검증 도메인 로직 구현](https://github.com/project-porko/porko-service/commit/f8cdef136e350fa75dea84d04951a0674554d98a)
- [로그인 API 구현](https://github.com/project-porko/porko-service/commit/60b825fc7d680b5e3a4e06e9a19afe67711989ed)
- [인증 필터 구현](https://github.com/project-porko/porko-service/commit/cac5c7fc38e5a78f4b55fedf6b6a623deb846828)
- [인증 관련 예외 핸들러 구현](https://github.com/project-porko/porko-service/commit/df3e1441995823673d0b0d5efa030cb3f40dd94d)

---
This closes #9, #13