### PR TITLE
feat: 내 정보 조회 API 구현

### DIFF
--- a/porko-service/src/main/java/io/porko/auth/controller/model/LoginMember.java
+++ b/porko-service/src/main/java/io/porko/auth/controller/model/LoginMember.java
@@ -1,0 +1,13 @@
+package io.porko.auth.controller.model;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal(expression = "#this =='anonymousUser' ? null : #this.getId()")
+public @interface LoginMember {
+}

--- a/porko-service/src/main/java/io/porko/member/controller/MemberController.java
+++ b/porko-service/src/main/java/io/porko/member/controller/MemberController.java
@@ -2,6 +2,8 @@ package io.porko.member.controller;
 
 import static io.porko.member.controller.MemberController.MEMBER_BASE_URI;
 
+import io.porko.auth.controller.model.LoginMember;
+import io.porko.member.controller.model.MemberResponse;
 import io.porko.member.controller.model.signup.SignUpRequest;
 import io.porko.member.controller.model.validateduplicate.ValidateDuplicateRequest;
 import io.porko.member.controller.model.validateduplicate.ValidateDuplicateResponse;
@@ -51,5 +53,11 @@ public class MemberController {
             GET_AN_MEMBER_URI_FORMAT,
             memberService.createMember(signUpRequest)
         );
+    }
+
+    @GetMapping("me")
+    ResponseEntity<MemberResponse> me(@LoginMember Long loginMemberId) {
+        MemberResponse memberResponse = memberService.loadMemberById(loginMemberId);
+        return ResponseEntity.ok(memberResponse);
     }
 }

--- a/porko-service/src/main/java/io/porko/member/controller/model/MemberResponse.java
+++ b/porko-service/src/main/java/io/porko/member/controller/model/MemberResponse.java
@@ -1,0 +1,23 @@
+package io.porko.member.controller.model;
+
+import io.porko.member.domain.Member;
+import java.time.LocalDateTime;
+
+public record MemberResponse(
+    Long id,
+    String memberId,
+    String name,
+    String email,
+    LocalDateTime registeredAt
+) {
+
+    public static MemberResponse of(Member member) {
+        return new MemberResponse(
+            member.getId(),
+            member.getMemberId(),
+            member.getName(),
+            member.getEmail(),
+            member.getCreatedAt()
+        );
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/exception/MemberErrorCode.java
+++ b/porko-service/src/main/java/io/porko/member/exception/MemberErrorCode.java
@@ -12,7 +12,8 @@ public enum MemberErrorCode {
     DUPLICATED_PHONE_NUMBER(BAD_REQUEST, "중복된 핸드폰 번호 입니다. [request: %s]"),
     INVALID_VALIDATE_DUPLICATE_VALUE_FORMAT(BAD_REQUEST, "중복 검사 대상 항목의 형식이 유효하지 않습니다. [request: %s]"),
     UNSUPPORTED_VALIDATE_DUPLICATE_TYPE(BAD_REQUEST, "지원하지 않는 중복 검사 대상 항목입니다. [request: %s]"),
-    ;
+
+    NOT_FOUND(HttpStatus.NOT_FOUND, "요청에 해당하는 사용자를 찾을 수 없습니다. [request: %s]");
 
     private final HttpStatus status;
     private final String message;

--- a/porko-service/src/main/java/io/porko/member/repo/MemberRepo.java
+++ b/porko-service/src/main/java/io/porko/member/repo/MemberRepo.java
@@ -1,6 +1,7 @@
 package io.porko.member.repo;
 
 import io.porko.member.domain.Member;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepo extends JpaRepository<Member, Long> {
@@ -9,4 +10,6 @@ public interface MemberRepo extends JpaRepository<Member, Long> {
     boolean existsByMemberId(String memberId);
 
     boolean existsByPhoneNumber(String phoneNumber);
+
+    Optional<Member> findByMemberId(String memberId);
 }

--- a/porko-service/src/main/java/io/porko/member/service/MemberService.java
+++ b/porko-service/src/main/java/io/porko/member/service/MemberService.java
@@ -4,7 +4,10 @@ import static io.porko.member.exception.MemberErrorCode.DUPLICATED_EMAIL;
 import static io.porko.member.exception.MemberErrorCode.DUPLICATED_MEMBER_ID;
 import static io.porko.member.exception.MemberErrorCode.DUPLICATED_PHONE_NUMBER;
 
+import io.porko.member.controller.model.MemberResponse;
 import io.porko.member.controller.model.signup.SignUpRequest;
+import io.porko.member.domain.Member;
+import io.porko.member.exception.MemberErrorCode;
 import io.porko.member.exception.MemberException;
 import io.porko.member.repo.MemberRepo;
 import lombok.RequiredArgsConstructor;
@@ -61,5 +64,14 @@ public class MemberService {
 
     private String encryptPassword(String password) {
         return passwordEncoder.encode(password);
+    }
+
+    public MemberResponse loadMemberById(Long id) {
+        return MemberResponse.of(findMemberById(id));
+    }
+
+    private Member findMemberById(Long id) {
+        return memberRepo.findById(id)
+            .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND, id));
     }
 }

--- a/porko-service/src/test/java/io/porko/member/controller/MemberControllerTestHelper.java
+++ b/porko-service/src/test/java/io/porko/member/controller/MemberControllerTestHelper.java
@@ -22,6 +22,7 @@ class MemberControllerTestHelper extends WebMvcTestBase {
 
     private static final String MEMBER_SIGN_UP_URI = "/member/sign-up";
     private static final String MEMBER_SIGN_UP_VALIDATE_DUPLICATE_URL = "/member/validate?type={type}&value={value}";
+    private static final String ME_URI = "/member/me";
     protected final SignUpRequest 유효_하지_않은_회원_가입_요청_객체 = new SignUpRequest(
         "",
         "",
@@ -35,12 +36,21 @@ class MemberControllerTestHelper extends WebMvcTestBase {
     protected Expect 회원_가입_요청(SignUpRequest 회원_가입_요청_정보) {
         return post()
             .url(MEMBER_SIGN_UP_URI)
+            .noAuthentication()
             .jsonContent(회원_가입_요청_정보);
     }
 
     protected Expect 중복_검사_요청(ValidateDuplicateType 중복_검사_타입, String 중복_검사_요청값) {
         return get()
             .url(MEMBER_SIGN_UP_VALIDATE_DUPLICATE_URL, 중복_검사_타입, 중복_검사_요청값)
+            .noAuthentication()
+            .expect();
+    }
+
+    protected Expect 내_정보_조회(){
+        return get()
+            .url(ME_URI)
+            .noAuthentication()
             .expect();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #19 내 정보 조회 API

## 📝작업 내용
- 내 정보 조회 관련 쿼리, 서비스, 컨트롤러 구현
- JWT 인증 필터를 통해 SecurityContextHolder에 저장된 Pricipal을 Custom하게 사용하기 위한 @LoginMember Annotation 구현
  - @LoginMember을 통해 컨트롤러 메서드 파라미터로 인증 정보를 주입

---
This closes #19 내 정보 조회 API