### PR TITLE
build: QueryDsl 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,7 +227,10 @@ gradle-app.setting
 ### intellij qodana plugin
 qodana.yaml
 
-### Docker:MySQL
+### Docker:MySQL volume
 .db/**
+
+### Querydsl q-class
+porko-service/src/main/generated/**
 
 # End of https://www.toptal.com/developers/gitignore/api/java,gradle,intellij+all,windows,macos,visualstudiocode

--- a/porko-common/build.gradle.kts
+++ b/porko-common/build.gradle.kts
@@ -9,7 +9,6 @@ repositories {
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0")
-    implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-web")
 
     testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter:1.0.14")

--- a/porko-common/src/test/java/io/porko/config/base/persistence/DatasourceTestConfig.java
+++ b/porko-common/src/test/java/io/porko/config/base/persistence/DatasourceTestConfig.java
@@ -2,14 +2,14 @@ package io.porko.config.base.persistence;
 
 import com.github.gavlyukovskiy.boot.jdbc.decorator.DataSourceDecoratorAutoConfiguration;
 import io.porko.config.base.TestBase;
-import io.porko.config.jpa.TestJpaConfiguration;
-import io.porko.config.p6spy.P6spySqlFormatConfiguration;
+import io.porko.config.jpa.TestJpaConfig;
+import io.porko.config.p6spy.P6spySqlFormatConfig;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.context.annotation.Import;
 
 @Import({
-    TestJpaConfiguration.class,
-    P6spySqlFormatConfiguration.class
+    TestJpaConfig.class,
+    P6spySqlFormatConfig.class
 })
 @ImportAutoConfiguration(DataSourceDecoratorAutoConfiguration.class)
 public abstract class DatasourceTestConfig extends TestBase {

--- a/porko-common/src/test/java/io/porko/config/jpa/TestJpaConfig.java
+++ b/porko-common/src/test/java/io/porko/config/jpa/TestJpaConfig.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 // TODO: Test 환경에서 사용할 사용자 정보를 통해 AuditingListener가 설정할 메타 데이터 제공
 @TestConfiguration
 @EnableJpaAuditing(modifyOnCreate = false)
-public class TestJpaConfiguration {
+public class TestJpaConfig {
 }

--- a/porko-common/src/test/java/io/porko/config/p6spy/P6spySqlFormatConfig.java
+++ b/porko-common/src/test/java/io/porko/config/p6spy/P6spySqlFormatConfig.java
@@ -12,7 +12,7 @@ import org.hibernate.engine.jdbc.internal.Formatter;
 import org.springframework.boot.test.context.TestComponent;
 
 @TestComponent
-public class P6spySqlFormatConfiguration extends JdbcEventListener implements MessageFormattingStrategy {
+public class P6spySqlFormatConfig extends JdbcEventListener implements MessageFormattingStrategy {
     public static final String CREATE = "create";
     public static final String ALTER = "alter";
     public static final String COMMENT = "comment";

--- a/porko-service/src/main/java/io/porko/member/config/jpa/auditor/MetaFields.java
+++ b/porko-service/src/main/java/io/porko/member/config/jpa/auditor/MetaFields.java
@@ -1,4 +1,4 @@
-package io.porko.config.jpa.auditor;
+package io.porko.member.config.jpa.auditor;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;

--- a/porko-service/src/main/java/io/porko/member/config/jpa/auditor/TimeMetaFields.java
+++ b/porko-service/src/main/java/io/porko/member/config/jpa/auditor/TimeMetaFields.java
@@ -1,4 +1,4 @@
-package io.porko.config.jpa.auditor;
+package io.porko.member.config.jpa.auditor;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;

--- a/porko-service/src/main/java/io/porko/member/config/querydsl/QueryDslConfig.java
+++ b/porko-service/src/main/java/io/porko/member/config/querydsl/QueryDslConfig.java
@@ -1,0 +1,18 @@
+package io.porko.member.config.querydsl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/controller/model/MemberResponse.java
+++ b/porko-service/src/main/java/io/porko/member/controller/model/MemberResponse.java
@@ -1,5 +1,6 @@
 package io.porko.member.controller.model;
 
+import com.querydsl.core.annotations.QueryProjection;
 import io.porko.member.domain.Member;
 import java.time.LocalDateTime;
 
@@ -10,6 +11,14 @@ public record MemberResponse(
     String email,
     LocalDateTime registeredAt
 ) {
+    @QueryProjection
+    public MemberResponse(Long id, String memberId, String name, String email, LocalDateTime registeredAt) {
+        this.id = id;
+        this.memberId = memberId;
+        this.name = name;
+        this.email = email;
+        this.registeredAt = registeredAt;
+    }
 
     public static MemberResponse of(Member member) {
         return new MemberResponse(

--- a/porko-service/src/main/java/io/porko/member/domain/Member.java
+++ b/porko-service/src/main/java/io/porko/member/domain/Member.java
@@ -1,6 +1,6 @@
 package io.porko.member.domain;
 
-import io.porko.config.jpa.auditor.TimeMetaFields;
+import io.porko.member.config.jpa.auditor.TimeMetaFields;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;

--- a/porko-service/src/main/java/io/porko/member/repo/MemberQueryRepo.java
+++ b/porko-service/src/main/java/io/porko/member/repo/MemberQueryRepo.java
@@ -1,0 +1,30 @@
+package io.porko.member.repo;
+
+import static io.porko.member.domain.QMember.member;
+
+import com.querydsl.jpa.JPQLQueryFactory;
+import io.porko.member.controller.model.MemberResponse;
+import io.porko.member.controller.model.QMemberResponse;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberQueryRepo {
+    private final JPQLQueryFactory queryFactory;
+
+    public Optional<MemberResponse> findMemberById(Long id) {
+        return Optional.ofNullable(queryFactory.select(
+                new QMemberResponse(
+                    member.id,
+                    member.memberId,
+                    member.name,
+                    member.email,
+                    member.createdAt
+                ))
+            .from(member)
+            .where(member.id.eq(id))
+            .fetchOne());
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/service/MemberService.java
+++ b/porko-service/src/main/java/io/porko/member/service/MemberService.java
@@ -6,9 +6,9 @@ import static io.porko.member.exception.MemberErrorCode.DUPLICATED_PHONE_NUMBER;
 
 import io.porko.member.controller.model.MemberResponse;
 import io.porko.member.controller.model.signup.SignUpRequest;
-import io.porko.member.domain.Member;
 import io.porko.member.exception.MemberErrorCode;
 import io.porko.member.exception.MemberException;
+import io.porko.member.repo.MemberQueryRepo;
 import io.porko.member.repo.MemberRepo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MemberService {
     private final MemberRepo memberRepo;
+    private final MemberQueryRepo memberQueryRepo;
     private final PasswordEncoder passwordEncoder;
 
     public boolean isDuplicatedMemberId(String memberId) {
@@ -67,11 +68,7 @@ public class MemberService {
     }
 
     public MemberResponse loadMemberById(Long id) {
-        return MemberResponse.of(findMemberById(id));
-    }
-
-    private Member findMemberById(Long id) {
-        return memberRepo.findById(id)
+        return memberQueryRepo.findMemberById(id)
             .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND, id));
     }
 }

--- a/porko-service/src/test/java/io/porko/config/querydsl/QueryDslTestBase.java
+++ b/porko-service/src/test/java/io/porko/config/querydsl/QueryDslTestBase.java
@@ -1,0 +1,8 @@
+package io.porko.config.querydsl;
+
+import io.porko.config.base.persistence.JpaTestBase;
+import org.springframework.context.annotation.Import;
+
+@Import(TestQueryDslConfig.class)
+public abstract class QueryDslTestBase extends JpaTestBase {
+}

--- a/porko-service/src/test/java/io/porko/config/querydsl/TestQueryDslConfig.java
+++ b/porko-service/src/test/java/io/porko/config/querydsl/TestQueryDslConfig.java
@@ -1,0 +1,24 @@
+package io.porko.config.querydsl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import io.porko.member.repo.MemberQueryRepo;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestQueryDslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+    @Bean
+    public MemberQueryRepo memberQueryRepo() {
+        return new MemberQueryRepo(jpaQueryFactory());
+    }
+}

--- a/porko-service/src/test/java/io/porko/member/repo/MemberQueryRepoTest.java
+++ b/porko-service/src/test/java/io/porko/member/repo/MemberQueryRepoTest.java
@@ -1,0 +1,30 @@
+package io.porko.member.repo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.porko.config.querydsl.QueryDslTestBase;
+import io.porko.member.controller.model.MemberResponse;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.jdbc.Sql;
+
+@DisplayName("Repo:Query:Member")
+class MemberQueryRepoTest extends QueryDslTestBase {
+    private final MemberQueryRepo memberQueryRepo;
+
+    public MemberQueryRepoTest(MemberQueryRepo memberQueryRepo) {
+        this.memberQueryRepo = memberQueryRepo;
+    }
+
+    @Sql("classpath:data.sql")
+    @Test
+    @DisplayName("회원 조회")
+    void findMemberById() {
+        // When
+        MemberResponse actual = Assertions.assertDoesNotThrow(() -> memberQueryRepo.findMemberById(1L).orElseThrow());
+
+        // Then
+        assertThat(actual).isNotNull();
+    }
+}

--- a/porko-service/src/test/resources/data.sql
+++ b/porko-service/src/test/resources/data.sql
@@ -1,0 +1,6 @@
+    insert 
+    into
+        member
+        (detail, road_name, created_at, email, gender, member_id, name, password, phone_number, updated_at) 
+    values
+        ('반포동','서울시 서초구','2024-05-21T03:29:30.044','project.log.062@gmail.com','MALE','choiys','최용석','{bcrypt}$2a$10$8VSoF7WnqGiFDp0XPA93IuKtMLR17Tte6ROVBS8ORVX8nQnJjbJYS','01011112222',NULL);


### PR DESCRIPTION
## #️⃣연관된 이슈

>  #24 QueryDsl 설정

## 📝작업 내용
- [querydsl 의존성 추가](https://github.com/project-porko/porko-service/commit/383cba7567451c869f1e9cf9d53c3c20fc4248a0)
- [porko-common에 위치한 jpa 관련 auditing entity 이관](https://github.com/project-porko/porko-service/commit/4167783ef5d8a613beae605e80d528109de7c611)
- [querydsl compile 결과 생성되는 q-class gitignore 등록](https://github.com/project-porko/porko-service/commit/9bead4f0cf9ac7396b4908b22641226d4669651c)
- [querydsl configuration 등록](https://github.com/project-porko/porko-service/commit/a0fe624883e847d084bcf0fb8a36696624d9dac9)
- [querydsl을 이용한 회원 조회 쿼리 추가](https://github.com/project-porko/porko-service/commit/4014b3737b97b76ba4cc0911e44c6def238e8e2e)
- [기존 JPA Repository를 이용한 회원 조회 부를 QueryDsl Repository로 변경](https://github.com/project-porko/porko-service/commit/f2ab769e2e32ddfaf931453c7de568137670f3cd)

---
This closes #24 QueryDsl 설정