### PR TITLE
config: local 환경의 application properties 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -228,7 +228,7 @@ gradle-app.setting
 qodana.yaml
 
 ### Docker:MySQL volume
-.db/**
+db/**
 
 ### Querydsl q-class
 porko-service/src/main/generated/**

--- a/porko-common/src/main/resources/application.yml
+++ b/porko-common/src/main/resources/application.yml
@@ -3,7 +3,12 @@ spring:
     import:
       - classpath:properties/datasource.yml
       - classpath:properties/jpa.yml
+      - classpath:properties/port.yml
+      - classpath:properties/jwt.yml
+      - classpath:properties/logging.yml
+      - classpath:properties/sql-init.yml
+      - classpath:properties/p6spy.yml
   profiles:
     group:
       test: h2-test, jpa-test
-      local: mysql-local, jpa-local, p6spy-local, logging-local
+      local: port-local, jwt-local, logging-local, sql-init-local, p6spy-local, mysql-local, jpa-local

--- a/porko-common/src/main/resources/properties/jwt.yml
+++ b/porko-common/src/main/resources/properties/jwt.yml
@@ -1,0 +1,6 @@
+spring.config.activate.on-profile: jwt-local
+jwt:
+  issuer: porko.info
+  secret-key: porko-service-local-secret-key
+  expire-period: 10
+  audience: porko-service

--- a/porko-common/src/main/resources/properties/logging.yml
+++ b/porko-common/src/main/resources/properties/logging.yml
@@ -1,0 +1,6 @@
+spring.config.activate.on-profile: logging-local
+logging:
+  level:
+    io.porko: debug
+    org.springframework.web.servlet: debug
+    org.hibernate.type.descriptor.sql.BasicBinder: trace

--- a/porko-common/src/main/resources/properties/p6spy.yml
+++ b/porko-common/src/main/resources/properties/p6spy.yml
@@ -1,0 +1,5 @@
+spring.config.activate.on-profile: p6spy-local
+decorator:
+  datasource:
+    p6spy:
+      enable-logging: false

--- a/porko-common/src/main/resources/properties/port.yml
+++ b/porko-common/src/main/resources/properties/port.yml
@@ -1,0 +1,3 @@
+spring.config.activate.on-profile: port-local
+server:
+  port: 8080

--- a/porko-common/src/main/resources/properties/sql-init.yml
+++ b/porko-common/src/main/resources/properties/sql-init.yml
@@ -1,0 +1,5 @@
+spring:
+  config.activate.on-profile: sql-init-local
+  sql.init.mode: always
+  jpa:
+    defer-datasource-initialization: true

--- a/porko-service/src/main/resources/application-service.yml
+++ b/porko-service/src/main/resources/application-service.yml
@@ -4,12 +4,3 @@ spring:
 
   profiles:
     active: local
-
-server:
-  port: 8080
-
-jwt:
-  issuer: porko.info
-  secret-key: porko-service-local-secret-key
-  expire-period: 10
-  audience: porko-service

--- a/porko-service/src/main/resources/data.sql
+++ b/porko-service/src/main/resources/data.sql
@@ -1,0 +1,9 @@
+    insert
+    into
+        member
+        (detail, road_name, created_at, email, gender, member_id, name, password, phone_number, updated_at)
+    values
+        ('반포동','서울시 서초구','2024-05-21T03:29:30.044','project.log.062@gmail.com','MALE','choiys','최용석',
+        '{bcrypt}$2a$10$8VSoF7WnqGiFDp0XPA93IuKtMLR17Tte6ROVBS8ORVX8nQnJjbJYS','01011112222',NULL);
+
+---


### PR DESCRIPTION
## #️⃣연관된 이슈

>  #27 local 환경의 application properties 수정

## 📝작업 내용
- [local 환경의 application properties 수정](https://github.com/project-porko/porko-service/commit/e57669f65b1441da9c2c0e664c8e890028d23b25)
  - 모든 환경 변수 설정을 porko-common으로 이관
    - porko-common을 의존하는 모든 모듈은 porko-common에서 정의한 profiles별 group을 이용하여 환경 변수 주입
- jwt, port 등 local application 구동에 필요한 환경 변수 추가 작성
- 디버깅을 위한 로깅 관련 환경 변수 추가(p6spy, logging-level)

데이터 초기화를 위한 JPA 사용 환경에서 SQL 스크립트 실행 관련 설정 추가
- [local 환경에서 초기 데이터 초기화를 위한 sql script 추가](https://github.com/project-porko/porko-service/commit/6151233ff98fa9798dfb9743f3e16ab2dd3e2bba)

---
This closes #27 local 환경의 application properties 수정