### PR TITLE
feat: 중복 검사 가능 항목 조회 API 구현

### DIFF
--- a/porko-common/src/test/java/io/porko/config/base/presentation/RequestBuilder.java
+++ b/porko-common/src/test/java/io/porko/config/base/presentation/RequestBuilder.java
@@ -105,11 +105,6 @@ public class RequestBuilder {
     }
 
     public class EndPoint {
-        //        public Content url(final String urlInput, final Object... urlVariablesInput) {
-//            url = urlInput;
-//            urlVariables = Arrays.asList(urlVariablesInput);
-//            return new Content();
-//        }
         public Header url(final String urlInput, final Object... urlVariablesInput) {
             url = urlInput;
             urlVariables = Arrays.asList(urlVariablesInput);

--- a/porko-service/src/main/java/io/porko/auth/config/SecurityConfig.java
+++ b/porko-service/src/main/java/io/porko/auth/config/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
             // [TODO:Refactor] endpoint, roles에 따른 인가 정책 가독성 개선을 위한 AuthenticationEndpointByRoles 적용
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(HttpMethod.POST, "/member/sign-up", "/login").permitAll()
-                .requestMatchers(HttpMethod.GET, "/member/validate").permitAll()
+                .requestMatchers(HttpMethod.GET, "/member/validate", "/member/validate/types").permitAll()
                 .anyRequest().authenticated()
             )
             // [TODO:Feature] : 403 권한 없음 예외 처리를 위한 AccessDeniedHandler 구현 및 등록

--- a/porko-service/src/main/java/io/porko/member/controller/MemberController.java
+++ b/porko-service/src/main/java/io/porko/member/controller/MemberController.java
@@ -8,6 +8,7 @@ import io.porko.member.controller.model.signup.SignUpRequest;
 import io.porko.member.controller.model.validateduplicate.ValidateDuplicateRequest;
 import io.porko.member.controller.model.validateduplicate.ValidateDuplicateResponse;
 import io.porko.member.controller.model.validateduplicate.ValidateDuplicateType;
+import io.porko.member.controller.model.validateduplicate.ValidateDuplicateTypeResponse;
 import io.porko.member.facade.ValidateDuplicateFacade;
 import io.porko.member.service.MemberService;
 import io.porko.utils.ResponseEntityUtils;
@@ -35,6 +36,11 @@ public class MemberController {
 
     private final ValidateDuplicateFacade validateDuplicateFacade;
     private final MemberService memberService;
+
+    @GetMapping("validate/types")
+    ResponseEntity<ValidateDuplicateTypeResponse> getValidateDuplicateTypes() {
+        return ResponseEntity.ok(ValidateDuplicateTypeResponse.create());
+    }
 
     @GetMapping("validate")
     ResponseEntity<ValidateDuplicateResponse> validateDuplicate(

--- a/porko-service/src/main/java/io/porko/member/controller/model/validateduplicate/ValidateDuplicateRequest.java
+++ b/porko-service/src/main/java/io/porko/member/controller/model/validateduplicate/ValidateDuplicateRequest.java
@@ -11,6 +11,7 @@ public record ValidateDuplicateRequest(
     String value
 ) {
     public static ValidateDuplicateRequest of(ValidateDuplicateType requestType, String value) {
+        requestType.validateFormat(value);
         return new ValidateDuplicateRequest(requestType, value);
     }
 }

--- a/porko-service/src/main/java/io/porko/member/controller/model/validateduplicate/ValidateDuplicateType.java
+++ b/porko-service/src/main/java/io/porko/member/controller/model/validateduplicate/ValidateDuplicateType.java
@@ -5,17 +5,20 @@ import static java.util.regex.Pattern.compile;
 import io.porko.member.exception.MemberErrorCode;
 import io.porko.member.exception.MemberException;
 import java.util.regex.Pattern;
+import lombok.Getter;
 
+@Getter
 public enum ValidateDuplicateType {
-    MEMBER_ID(compile("^[a-zA-Z0-9]{6,20}$")),
-    EMAIL(compile("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$")),
-    PHONE_NUMBER(compile("^[0-9]{11}$"))
-    ;
+    MEMBER_ID(compile("^[a-zA-Z0-9]{6,20}$"), "아이디"),
+    EMAIL(compile("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$"), "이메일"),
+    PHONE_NUMBER(compile("^[0-9]{11}$"), "휴대폰 번호");
 
     private final Pattern pattern;
+    private final String description;
 
-    ValidateDuplicateType(Pattern pattern) {
+    ValidateDuplicateType(Pattern pattern, String description) {
         this.pattern = pattern;
+        this.description = description;
     }
 
     public void validateFormat(String value) {

--- a/porko-service/src/main/java/io/porko/member/controller/model/validateduplicate/ValidateDuplicateTypeDto.java
+++ b/porko-service/src/main/java/io/porko/member/controller/model/validateduplicate/ValidateDuplicateTypeDto.java
@@ -1,0 +1,10 @@
+package io.porko.member.controller.model.validateduplicate;
+
+public record ValidateDuplicateTypeDto(
+    String field,
+    String description
+) {
+    public static ValidateDuplicateTypeDto of(ValidateDuplicateType validateDuplicateType) {
+        return new ValidateDuplicateTypeDto(validateDuplicateType.name(), validateDuplicateType.getDescription());
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/controller/model/validateduplicate/ValidateDuplicateTypeResponse.java
+++ b/porko-service/src/main/java/io/porko/member/controller/model/validateduplicate/ValidateDuplicateTypeResponse.java
@@ -1,0 +1,15 @@
+package io.porko.member.controller.model.validateduplicate;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record ValidateDuplicateTypeResponse(
+    List<ValidateDuplicateTypeDto> elements
+) {
+    public static ValidateDuplicateTypeResponse create() {
+        return new ValidateDuplicateTypeResponse(Arrays.stream(ValidateDuplicateType.values())
+            .map(ValidateDuplicateTypeDto::of)
+            .collect(Collectors.toList()));
+    }
+}

--- a/porko-service/src/test/java/io/porko/member/controller/MemberControllerTest.java
+++ b/porko-service/src/test/java/io/porko/member/controller/MemberControllerTest.java
@@ -8,11 +8,13 @@ import static io.porko.member.controller.model.validateduplicate.ValidateDuplica
 import static io.porko.member.controller.model.validateduplicate.ValidateDuplicateType.MEMBER_ID;
 import static io.porko.member.controller.model.validateduplicate.ValidateDuplicateType.PHONE_NUMBER;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasItems;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.http.HttpHeaders.LOCATION;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 import io.porko.config.fixture.FixtureCommon;
 import io.porko.config.security.TestSecurityConfig;
@@ -22,6 +24,8 @@ import io.porko.member.controller.model.validateduplicate.AvailabilityStatus;
 import io.porko.member.controller.model.validateduplicate.ValidateDuplicateRequest;
 import io.porko.member.controller.model.validateduplicate.ValidateDuplicateResponse;
 import io.porko.member.controller.model.validateduplicate.ValidateDuplicateType;
+import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,6 +41,29 @@ import org.springframework.test.web.servlet.ResultActions;
 @DisplayName("Controller:Member")
 @Import(TestSecurityConfig.class)
 class MemberControllerTest extends MemberControllerTestHelper {
+    @Test
+    @DisplayName("[중복 검사 가능 항목 조회][GET:200]")
+    void validateDuplicateTypes() throws Exception {
+        // When
+        ResultActions resultActions = get()
+            .url("/member/validate/types")
+            .noAuthentication()
+            .expect().ok();
+
+        // Then
+        List<String> expectedFields = Arrays.stream(ValidateDuplicateType.values())
+            .map(Enum::name)
+            .toList();
+
+        List<String> expectedDescriptions = Arrays.stream(ValidateDuplicateType.values())
+            .map(ValidateDuplicateType::getDescription)
+            .toList();
+
+        resultActions.andExpect(jsonPath("$.elements[*]").isArray())
+            .andExpect(jsonPath("$.elements[*].field", hasItems(expectedFields.toArray(new String[0]))))
+            .andExpect(jsonPath("$.elements[*].description", hasItems(expectedDescriptions.toArray(new String[0]))));
+    }
+
     @ParameterizedTest(name = "[{index}] 요청:[타입:{0}, 요청값:{1}], 중복 여부:{2}, 사용 가능 상태:{3}")
     @MethodSource
     @DisplayName("[회원 가입 항목 중복 검사][GET:200]")

--- a/porko-service/src/test/java/io/porko/member/controller/model/validateduplicate/ValidateDuplicateTypeDtoTest.java
+++ b/porko-service/src/test/java/io/porko/member/controller/model/validateduplicate/ValidateDuplicateTypeDtoTest.java
@@ -1,0 +1,33 @@
+package io.porko.member.controller.model.validateduplicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@DisplayName("Model:ValidateDuplicateTypeDto")
+class ValidateDuplicateTypeDtoTest {
+    @ParameterizedTest
+    @MethodSource
+    @DisplayName("ValidateDuplicateType Enum 정보를 반환하기 위한 DTO 생성")
+    void create(ValidateDuplicateType given) {
+        // When
+        ValidateDuplicateTypeDto actual = ValidateDuplicateTypeDto.of(given);
+
+        // Then
+        assertThat(actual)
+            .extracting(ValidateDuplicateTypeDto::field, ValidateDuplicateTypeDto::description)
+            .containsExactly(given.name(), given.getDescription());
+    }
+
+    private static Stream<Arguments> create() {
+        return Stream.of(
+            Arguments.of(ValidateDuplicateType.MEMBER_ID),
+            Arguments.of(ValidateDuplicateType.EMAIL),
+            Arguments.of(ValidateDuplicateType.PHONE_NUMBER)
+        );
+    }
+}

--- a/porko-service/src/test/java/io/porko/member/controller/model/validateduplicate/ValidateDuplicateTypeResponseTest.java
+++ b/porko-service/src/test/java/io/porko/member/controller/model/validateduplicate/ValidateDuplicateTypeResponseTest.java
@@ -1,0 +1,33 @@
+package io.porko.member.controller.model.validateduplicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Model:ValidateDuplicateTypeResponse")
+class ValidateDuplicateTypeResponseTest {
+    @Test
+    @DisplayName("ValidateDuplicateType Enum 목록 정보를 반환하기 위한 일급컬렉션 생성")
+    void convertTo() {
+        // When
+        ValidateDuplicateTypeResponse actual = ValidateDuplicateTypeResponse.create();
+
+        // Then
+        List<ValidateDuplicateType> types = Arrays.asList(ValidateDuplicateType.values());
+
+        assertThat(actual.elements())
+            .isNotNull()
+            .hasSize(types.size())
+            .extracting(ValidateDuplicateTypeDto::field, ValidateDuplicateTypeDto::description)
+            .containsExactlyElementsOf(
+                types.stream()
+                    .map(type -> Tuple.tuple(type.name(), type.getDescription()))
+                    .collect(Collectors.toList())
+            );
+    }
+}

--- a/porko-service/src/test/java/io/porko/member/facade/ValidateDuplicateFacadeTest.java
+++ b/porko-service/src/test/java/io/porko/member/facade/ValidateDuplicateFacadeTest.java
@@ -1,18 +1,14 @@
 package io.porko.member.facade;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import io.porko.config.base.business.ServiceTestBase;
 import io.porko.member.controller.model.validateduplicate.AvailabilityStatus;
 import io.porko.member.controller.model.validateduplicate.ValidateDuplicateRequest;
 import io.porko.member.controller.model.validateduplicate.ValidateDuplicateResponse;
-import io.porko.member.exception.MemberErrorCode;
-import io.porko.member.exception.MemberException;
 import io.porko.member.controller.model.validateduplicate.ValidateDuplicateType;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -44,19 +40,5 @@ class ValidateDuplicateFacadeTest extends ServiceTestBase {
             Arguments.of(ValidateDuplicateRequest.of(ValidateDuplicateType.MEMBER_ID, "porkoMemberId")),
             Arguments.of(ValidateDuplicateRequest.of(ValidateDuplicateType.EMAIL, "testMember@porko.info"))
         );
-    }
-
-    @Test
-    @DisplayName("[예외]중복 여부 검사 타입이 유효하지 않은 경우")
-    void throwMemberException_WhenValidateDuplicateRequest() {
-        // Given
-        ValidateDuplicateRequest given = ValidateDuplicateRequest.of(null, null);
-
-        // When & Then
-        assertThatExceptionOfType(MemberException.class)
-            .isThrownBy(() -> validateDuplicateFacade.isDuplicated(given))
-            .extracting(MemberException::getCode)
-            .isEqualTo(MemberErrorCode.UNSUPPORTED_VALIDATE_DUPLICATE_TYPE.name())
-        ;
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #31 중복 검사 가능 항목 조회 API 구현

## 📝작업 내용
- [중복 검사 가능 항목 응답을 위한 객체 변환 및 응답 객체 정의](https://github.com/project-porko/porko-service/commit/9f8f9c3000921f5d1eb510d09fcf9d1f90c954f6)
- [중복 검사 가능 항목 조회 API 구현](https://github.com/project-porko/porko-service/commit/b3e77a33330b923018f449774ee184bf2d98583d)
  - 별도 인증 절차 없이 해당 API 호출이 가능하도록 Security 인가 정책 등록

---
This closes #31 중복 검사 가능 항목 조회 API 구현
