### PR TITLE
config: 민감한 환경 변수 분리 및 주입

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -233,4 +233,7 @@ db/**
 ### Querydsl q-class
 porko-service/src/main/generated/**
 
+### application environment properties
+porko-common/src/main/resources/environment/**
+
 # End of https://www.toptal.com/developers/gitignore/api/java,gradle,intellij+all,windows,macos,visualstudiocode

--- a/.gitignore
+++ b/.gitignore
@@ -236,4 +236,7 @@ porko-service/src/main/generated/**
 ### application environment properties
 porko-common/src/main/resources/environment/**
 
+### docker environment properties
+.env
+
 # End of https://www.toptal.com/developers/gitignore/api/java,gradle,intellij+all,windows,macos,visualstudiocode

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,19 @@
-version: '3.7'
+version: '3.9'
 services:
   mysql:
+    env_file: .env
     container_name: porko-mysql
     image: mysql:8.0
     command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --lower_case_table_names=1
     ports:
-      - "3306:3306"
+      - ${EXPOSE_PORT}:${TARGET_PORT}
     volumes:
       - ./db/conf.d:/etc/mysql/conf.d
       - ./db/data/porko:/var/lib/mysql
       - ./db/initdb.d:/docker-entrypoint-initdb.d
     environment:
       - TZ=Asia/Seoul
-      - MYSQL_DATABASE=porko
-      - MYSQL_ROOT_PASSWORD=porko-root-pw
-      - MYSQL_USER=porko-local
-      - MYSQL_PASSWORD=porko-local-pw
+      - MYSQL_DATABASE=${MYSQL_DATABASE}
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+      - MYSQL_USER=${MYSQL_USER}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}

--- a/porko-common/src/main/resources/application.yml
+++ b/porko-common/src/main/resources/application.yml
@@ -8,7 +8,8 @@ spring:
       - classpath:properties/logging.yml
       - classpath:properties/sql-init.yml
       - classpath:properties/p6spy.yml
+      - classpath:environment/env.yml
   profiles:
     group:
-      test: h2-test, jpa-test
+      test: h2-test, jpa-test, jwt-test
       local: port-local, jwt-local, logging-local, sql-init-local, p6spy-local, mysql-local, jpa-local

--- a/porko-common/src/main/resources/properties/datasource.yml
+++ b/porko-common/src/main/resources/properties/datasource.yml
@@ -10,8 +10,8 @@ spring:
   datasource:
     platform: mysql
     hikari:
-      jdbc-url: jdbc:h2:mem:test_db;MODE=MySql
-    username: sa
+      jdbc-url: ${datasource.url}
+    username: ${datasource.username}
     password:
   test.database.replace: none
   sql.init.mode: never
@@ -19,7 +19,7 @@ spring:
 spring:
   config.activate.on-profile: mysql-local
   datasource:
-    url: jdbc:mysql://localhost:3306/porko?useUnicode=yes&characterEncoding=UTF-8&rewriteBatchedStatements=true
+    url: ${datasource.url}
     driver-class-name: com.mysql.cj.jdbc.Driver
-    username: porko-local
-    password: porko-local-pw
+    username: ${datasource.username}
+    password: ${datasource.password}

--- a/porko-common/src/main/resources/properties/jwt.yml
+++ b/porko-common/src/main/resources/properties/jwt.yml
@@ -1,6 +1,11 @@
-spring.config.activate.on-profile: jwt-local
 jwt:
   issuer: porko.info
-  secret-key: porko-service-local-secret-key
   expire-period: 10
   audience: porko-service
+---
+spring.config.activate.on-profile: jwt-test
+jwt.secret-key: ${jwt.secret-key}
+---
+spring.config.activate.on-profile: jwt-local
+jwt.secret-key: ${jwt.secret-key}
+---

--- a/porko-service/src/test/resources/application-test.yml
+++ b/porko-service/src/test/resources/application-test.yml
@@ -1,5 +1,0 @@
-jwt:
-  issuer: porko.info
-  secret-key: porko-service-test-secret-key
-  expire-period: 10
-  audience: porko-service


### PR DESCRIPTION
## #️⃣연관된 이슈

> #34 민감한 환경 변수 분리 및 주입

## 📝작업 내용

현재 버전관리 되고 있는 *.yml(application.yml, docker-compose.yml)에 접속정보와 key같은 민감한 정보가 포함되어 있어, 민감한 환경 변수를 별도 파일로 추출하고 Application 구동 시 주입 받아 실행 할 수 있도록 수정하였습니다.

###  application properties의 민감한 환경 변수 분리
- [*.yml의 민감한 환경 변수 추출 및 gitignore 등록](https://github.com/project-porko/porko-service/commit/f2d4d4f78079a7dbc7dfb27d1efc5c9f10efa785)
- [분리한 환경 변수 파일 import](https://github.com/project-porko/porko-service/commit/391a0b2b161ee4f2d63f9cb0392ebc3ad7527980)
- [env 파일의 민감한 환경 변수 주입](https://github.com/project-porko/porko-service/commit/b58ee446d2106b9dff46f6ec4ee239a127057a33)

#### docker compose의 민감한 환경 변수 분리
- [docker compose의 민감한 환경 변수 추출 및 gitignore 등록](https://github.com/project-porko/porko-service/commit/8bc67d2d19a1cfd9d8efeecf2f32361563a958fc)
- [docker compose에 환경 변수 주입](https://github.com/project-porko/porko-service/commit/1dff93565cfe899c6c1cc882e8d6fc838a808dbb)

---
This closes #34 민감한 환경 변수 분리 및 주입

