### PR TITLE
feat: LocalCahce 적용(Caffeine)

### DIFF
--- a/porko-common/src/test/java/io/porko/config/utils/TestUtils.java
+++ b/porko-common/src/test/java/io/porko/config/utils/TestUtils.java
@@ -1,0 +1,11 @@
+package io.porko.config.utils;
+
+import java.util.stream.IntStream;
+
+public class TestUtils {
+    public static void repeat(int count, Runnable runnable) {
+        IntStream.range(0, count).forEach((i) -> {
+            runnable.run();
+        });
+    }
+}

--- a/porko-common/src/test/java/io/porko/config/utils/TestUtils.java
+++ b/porko-common/src/test/java/io/porko/config/utils/TestUtils.java
@@ -4,8 +4,6 @@ import java.util.stream.IntStream;
 
 public class TestUtils {
     public static void repeat(int count, Runnable runnable) {
-        IntStream.range(0, count).forEach((i) -> {
-            runnable.run();
-        });
+        IntStream.range(0, count).forEach((i) -> runnable.run());
     }
 }

--- a/porko-service/build.gradle.kts
+++ b/porko-service/build.gradle.kts
@@ -21,13 +21,15 @@ dependencies {
     annotationProcessor("jakarta.annotation:jakarta.annotation-api")
     annotationProcessor("jakarta.persistence:jakarta.persistence-api")
 
+    implementation("org.springframework.boot:spring-boot-starter-cache")
+    implementation("com.github.ben-manes.caffeine:caffeine")
+
     testRuntimeOnly("com.h2database:h2")
     runtimeOnly("com.mysql:mysql-connector-j")
 
     testImplementation("org.springframework.security:spring-security-test")
     testImplementation(testSourceSet)
 }
-
 
 tasks.withType<Test> {
     useJUnitPlatform()
@@ -47,6 +49,6 @@ tasks.withType<JavaCompile> {
 
 tasks {
     getByName<Delete>("clean") {
-        delete.add(qClassGeneratedPath) // add accepts argument with Any type
+        delete.add(qClassGeneratedPath)
     }
 }

--- a/porko-service/src/main/java/io/porko/config/cache/CacheConfig.java
+++ b/porko-service/src/main/java/io/porko/config/cache/CacheConfig.java
@@ -1,0 +1,33 @@
+package io.porko.config.cache;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+    @Bean
+    public List<CaffeineCache> caffeineCaches() {
+        return Arrays.stream(CacheType.values())
+            .map(cache -> new CaffeineCache(cache.getName(), Caffeine.newBuilder().recordStats()
+                .expireAfterWrite(cache.getMaxElementSize(), TimeUnit.HOURS)
+                .maximumSize(cache.getMaxElementSize())
+                .build()))
+            .toList();
+    }
+
+    @Bean
+    public CacheManager cacheManager(List<CaffeineCache> caffeineCaches) {
+        SimpleCacheManager cacheManager = new SimpleCacheManager();
+        cacheManager.setCaches(caffeineCaches);
+        return cacheManager;
+    }
+}

--- a/porko-service/src/main/java/io/porko/config/cache/CacheConfig.java
+++ b/porko-service/src/main/java/io/porko/config/cache/CacheConfig.java
@@ -1,9 +1,12 @@
 package io.porko.config.cache;
 
+import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.caffeine.CaffeineCache;
@@ -11,23 +14,36 @@ import org.springframework.cache.support.SimpleCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+@Slf4j
 @Configuration
 @EnableCaching
 public class CacheConfig {
-    @Bean
-    public List<CaffeineCache> caffeineCaches() {
-        return Arrays.stream(CacheType.values())
-            .map(cache -> new CaffeineCache(cache.getName(), Caffeine.newBuilder().recordStats()
-                .expireAfterWrite(cache.getMaxElementSize(), TimeUnit.HOURS)
-                .maximumSize(cache.getMaxElementSize())
-                .build()))
-            .toList();
-    }
-
     @Bean
     public CacheManager cacheManager(List<CaffeineCache> caffeineCaches) {
         SimpleCacheManager cacheManager = new SimpleCacheManager();
         cacheManager.setCaches(caffeineCaches);
         return cacheManager;
+    }
+
+    @Bean
+    public List<CaffeineCache> caffeineCaches() {
+        return Arrays.stream(CacheType.values())
+            .map(this::createCaffeineCache)
+            .toList();
+    }
+
+    private CaffeineCache createCaffeineCache(CacheType cacheType) {
+        return new CaffeineCache(cacheType.getName(), cacheBuilder(cacheType));
+    }
+    
+    private Cache<Object, Object> cacheBuilder(CacheType cacheType) {
+        return Caffeine.newBuilder()
+            .expireAfterWrite(cacheType.getMaxElementSize(), TimeUnit.HOURS)
+            .maximumSize(cacheType.getMaxElementSize())
+            .evictionListener((Object key, Object value, RemovalCause cause) ->
+                log.warn("Key [{}] was evicted ({}): {}", key, cause, value)
+            )
+            .recordStats()
+            .build();
     }
 }

--- a/porko-service/src/main/java/io/porko/config/cache/CacheType.java
+++ b/porko-service/src/main/java/io/porko/config/cache/CacheType.java
@@ -1,0 +1,14 @@
+package io.porko.config.cache;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+enum CacheType {
+    WIDGETS("widgets", 24, 10000);
+
+    private final String name;
+    private final long timeToLiveHours;
+    private final int maxElementSize;
+}

--- a/porko-service/src/main/java/io/porko/config/cache/CacheType.java
+++ b/porko-service/src/main/java/io/porko/config/cache/CacheType.java
@@ -1,14 +1,26 @@
 package io.porko.config.cache;
 
+import static io.porko.config.cache.CacheType.DefaultCacheProperties.DEFAULT_MAX_ELEMENTS_SIZE;
+import static io.porko.config.cache.CacheType.DefaultCacheProperties.TIME_TO_LIVE_HOURS;
+
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
-enum CacheType {
-    WIDGETS("widgets", 24, 10000);
+public enum CacheType {
+    WIDGETS("widgets");
 
     private final String name;
     private final long timeToLiveHours;
     private final int maxElementSize;
+
+    CacheType(String name) {
+        this.name = name;
+        this.timeToLiveHours = TIME_TO_LIVE_HOURS;
+        this.maxElementSize = DEFAULT_MAX_ELEMENTS_SIZE;
+    }
+
+    static class DefaultCacheProperties {
+        static final int TIME_TO_LIVE_HOURS = 24;
+        static final int DEFAULT_MAX_ELEMENTS_SIZE = 10000;
+    }
 }

--- a/porko-service/src/main/java/io/porko/widget/service/WidgetService.java
+++ b/porko-service/src/main/java/io/porko/widget/service/WidgetService.java
@@ -4,6 +4,7 @@ package io.porko.widget.service;
 import io.porko.widget.controller.model.WidgetsResponse;
 import io.porko.widget.repo.WidgetRepo;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class WidgetService {
     private final WidgetRepo widgetRepo;
 
+    @Cacheable(cacheNames = "widgets", key = "#root.methodName")
     public WidgetsResponse loadAllWidgets() {
         return WidgetsResponse.from(widgetRepo.findAll());
     }

--- a/porko-service/src/main/resources/data.sql
+++ b/porko-service/src/main/resources/data.sql
@@ -1,9 +1,18 @@
-    insert
-    into
-        member
-        (detail, road_name, created_at, email, gender, member_id, name, password, phone_number, updated_at)
-    values
-        ('반포동','서울시 서초구','2024-05-21T03:29:30.044','project.log.062@gmail.com','MALE','choiys','최용석',
-        '{bcrypt}$2a$10$8VSoF7WnqGiFDp0XPA93IuKtMLR17Tte6ROVBS8ORVX8nQnJjbJYS','01011112222',NULL);
+insert into member(detail, road_name, created_at, email, gender, name, password, phone_number, updated_at) values
+    ('반포동','서울시 서초구','2024-05-21T03:29:30.044','project.log.062@gmail.com','MALE','최용석','{bcrypt}$2a$10$8VSoF7WnqGiFDp0XPA93IuKtMLR17Tte6ROVBS8ORVX8nQnJjbJYS','01011112222',NULL);
 
 ---
+-- widget
+insert into widget (widget_code) values
+    ('TODAY_CONSUMPTION_WEATHER'),
+    ('REMAINING_BUDGET'),
+    ('UPCOMING_EXPENSES'),
+    ('LAST_MONTH_EXPENSES'),
+    ('CURRENT_MONTH_EXPENSES'),
+    ('CURRENT_MONTH_CARD_USAGE'),
+    ('MY_CHALLENGE'),
+    ('DAILY_EXPENSES'),
+    ('CREDIT_SCORE'),
+    ('INVESTMENT_RANKING'),
+    ('STEP_COUNT'),
+    ('DAILY_HOROSCOPE');

--- a/porko-service/src/test/java/io/porko/config/cache/CacheConfigTest.java
+++ b/porko-service/src/test/java/io/porko/config/cache/CacheConfigTest.java
@@ -1,0 +1,97 @@
+package io.porko.config.cache;
+
+import static io.porko.widget.controller.WidgetControllerTestHelper.widgets;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCache;
+
+@DisplayName("Config:Cache")
+@WebMvcTest(controllers = CacheManager.class)
+class CacheConfigTest extends CacheConfigTestHelper {
+    @SpyBean
+    private CacheManager cacheManager;
+
+    @BeforeEach
+    void setUp() {
+        cacheManager.getCache(CacheType.WIDGETS.getName()).putIfAbsent(CacheType.WIDGETS.getName(), widgets);
+    }
+
+    @AfterEach
+    void tearDown() {
+        cacheManager.getCache(CacheType.WIDGETS.getName()).invalidate();
+    }
+
+    @Test
+    @DisplayName("캐시 매니저에 등록된 캐시 목록 확인")
+    void checkRegisteredCaches() {
+        // When
+        Collection<String> actual = cacheManager.getCacheNames();
+
+        // Then
+        assertThat(actual).containsExactly(CacheType.WIDGETS.getName());
+    }
+
+    @Test
+    @DisplayName("각 캐시의 모든 key 목록 확인")
+    public void getAllKeyAndValue() {
+        // When
+        Map<String, List<String>> cacheMapInfo = cacheManager.getCacheNames().stream()
+            .collect(Collectors.toMap(
+                cacheName -> cacheName,
+                cacheName -> {
+                    Cache<Object, Object> nativeCache = ((CaffeineCache) cacheManager.getCache(cacheName)).getNativeCache();
+                    return nativeCache.asMap().keySet().stream()
+                        .map(Object::toString)
+                        .collect(Collectors.toList());
+                }
+            ));
+
+        // Then
+        assertThat(cacheMapInfo).containsKeys(CacheType.WIDGETS.getName());
+        assertThat(cacheMapInfo).containsValue(List.of(CacheType.WIDGETS.getName()));
+    }
+
+    @Test
+    @DisplayName("캐시 적중 여부 확인")
+    void checkHitCount() {
+        // Given
+        cacheManager.getCache(cacheName).putIfAbsent(testKey, testValue);
+
+        // When
+        String value = assertDoesNotThrow(() -> cacheManager.getCache(cacheName).get(testKey, String.class));
+        CacheStats actual = ((CaffeineCache) cacheManager.getCache(cacheName)).getNativeCache().stats();
+
+        // Then
+        assertThat(actual.hitCount()).isEqualTo(1);
+        assertThat(value).isEqualTo(testValue);
+    }
+
+    @Test
+    @DisplayName("evict에 의한 캐시 삭제 여부 확인")
+    void checkCacheEviction() {
+        cacheManager.getCache(cacheName).putIfAbsent(testKey, testValue);
+        ((CaffeineCache) cacheManager.getCache(cacheName)).evictIfPresent(testKey);
+
+        // When
+        String actual = assertDoesNotThrow(() -> cacheManager.getCache(cacheName).get(testKey, String.class));
+        CacheStats stats = ((CaffeineCache) cacheManager.getCache(cacheName)).getNativeCache().stats();
+
+        // Then
+        assertThat(actual).isNull();
+        assertThat(stats.hitCount()).isEqualTo(0);
+    }
+}

--- a/porko-service/src/test/java/io/porko/config/cache/CacheConfigTest.java
+++ b/porko-service/src/test/java/io/porko/config/cache/CacheConfigTest.java
@@ -1,6 +1,5 @@
 package io.porko.config.cache;
 
-import static io.porko.widget.controller.WidgetControllerTestHelper.widgets;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
@@ -10,31 +9,15 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.caffeine.CaffeineCache;
 
 @DisplayName("Config:Cache")
 @WebMvcTest(controllers = CacheManager.class)
 class CacheConfigTest extends CacheConfigTestHelper {
-    @SpyBean
-    private CacheManager cacheManager;
-
-    @BeforeEach
-    void setUp() {
-        cacheManager.getCache(CacheType.WIDGETS.getName()).putIfAbsent(CacheType.WIDGETS.getName(), widgets);
-    }
-
-    @AfterEach
-    void tearDown() {
-        cacheManager.getCache(CacheType.WIDGETS.getName()).invalidate();
-    }
-
     @Test
     @DisplayName("캐시 매니저에 등록된 캐시 목록 확인")
     void checkRegisteredCaches() {
@@ -84,7 +67,7 @@ class CacheConfigTest extends CacheConfigTestHelper {
     @DisplayName("evict에 의한 캐시 삭제 여부 확인")
     void checkCacheEviction() {
         cacheManager.getCache(cacheName).putIfAbsent(testKey, testValue);
-        ((CaffeineCache) cacheManager.getCache(cacheName)).evictIfPresent(testKey);
+        cacheManager.getCache(cacheName).evictIfPresent(testKey);
 
         // When
         String actual = assertDoesNotThrow(() -> cacheManager.getCache(cacheName).get(testKey, String.class));

--- a/porko-service/src/test/java/io/porko/config/cache/CacheConfigTestHelper.java
+++ b/porko-service/src/test/java/io/porko/config/cache/CacheConfigTestHelper.java
@@ -1,6 +1,12 @@
 package io.porko.config.cache;
 
+import static io.porko.widget.controller.WidgetControllerTestHelper.widgets;
+
 import io.porko.config.base.TestBase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Import;
 
 @Import(CacheConfig.class)
@@ -8,4 +14,17 @@ class CacheConfigTestHelper extends TestBase {
     protected final static String cacheName = CacheType.WIDGETS.getName();
     protected final static String testKey = "test::key";
     protected final static String testValue = "test-value";
+
+    @SpyBean
+    protected CacheManager cacheManager;
+
+    @BeforeEach
+    void setUp() {
+        cacheManager.getCache(CacheType.WIDGETS.getName()).putIfAbsent(CacheType.WIDGETS.getName(), widgets);
+    }
+
+    @AfterEach
+    void tearDown() {
+        cacheManager.getCache(CacheType.WIDGETS.getName()).invalidate();
+    }
 }

--- a/porko-service/src/test/java/io/porko/config/cache/CacheConfigTestHelper.java
+++ b/porko-service/src/test/java/io/porko/config/cache/CacheConfigTestHelper.java
@@ -1,0 +1,11 @@
+package io.porko.config.cache;
+
+import io.porko.config.base.TestBase;
+import org.springframework.context.annotation.Import;
+
+@Import(CacheConfig.class)
+class CacheConfigTestHelper extends TestBase {
+    protected final static String cacheName = CacheType.WIDGETS.getName();
+    protected final static String testKey = "test::key";
+    protected final static String testValue = "test-value";
+}

--- a/porko-service/src/test/java/io/porko/widget/service/WidgetServiceTest.java
+++ b/porko-service/src/test/java/io/porko/widget/service/WidgetServiceTest.java
@@ -1,35 +1,55 @@
 package io.porko.widget.service;
 
+import static io.porko.config.utils.TestUtils.repeat;
 import static io.porko.widget.controller.WidgetControllerTestHelper.widgets;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import io.porko.config.base.business.ServiceTestBase;
+import io.porko.config.base.TestBase;
+import io.porko.config.cache.CacheConfig;
+import io.porko.config.cache.CacheType;
 import io.porko.widget.controller.model.WidgetsResponse;
 import io.porko.widget.repo.WidgetRepo;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Import;
 
 @DisplayName("Service:Widget")
-class WidgetServiceTest extends ServiceTestBase {
-    @Mock
+@Import(CacheConfig.class)
+@WebMvcTest(controllers = {CacheManager.class, WidgetService.class})
+class WidgetServiceTest extends TestBase {
+    @MockBean
     private WidgetRepo widgetRepo;
 
-    @InjectMocks
-    private WidgetService widgetService;
+    @SpyBean
+    private CacheManager cacheManager;
+
+    private final WidgetService widgetService;
+
+    public WidgetServiceTest(WidgetService widgetService) {
+        this.widgetService = widgetService;
+    }
 
     @Test
-    @DisplayName("모든 위젯 조회")
+    @DisplayName("캐시를 통한 모든 위젯 조회")
     void loadAllWidgets() {
         // Given
+        final int repeatCount = 10;
         given(widgetRepo.findAll()).willReturn(widgets);
 
         // When
-        WidgetsResponse widgetsResponse = widgetService.loadAllWidgets();
+        repeat(repeatCount, () -> {
+            WidgetsResponse widgetsResponse = widgetService.loadAllWidgets();
+            System.out.println(widgetsResponse);
+        });
 
         // Then
-        verify(widgetRepo).findAll();
+        verify(cacheManager, times(repeatCount)).getCache(CacheType.WIDGETS.getName());
+        verify(widgetRepo, times(1)).findAll();
     }
 }

--- a/porko-service/src/test/resources/data.sql
+++ b/porko-service/src/test/resources/data.sql
@@ -1,6 +1,0 @@
-    insert 
-    into
-        member
-        (detail, road_name, created_at, email, gender, name, password, phone_number, updated_at)
-    values
-        ('반포동','서울시 서초구','2024-05-21T03:29:30.044','project.log.062@gmail.com','MALE','최용석','{bcrypt}$2a$10$8VSoF7WnqGiFDp0XPA93IuKtMLR17Tte6ROVBS8ORVX8nQnJjbJYS','01011112222',NULL);


### PR DESCRIPTION
## #️⃣연관된 이슈

> #43  LocalCahce 적용(Caffeine)

## 📝작업 내용
`모든 위젯 조회 API`는 별도의 호출 조건이 없는 정적 CODE 데이터로 캐시 TTL 내에서 수정/삭제 등의 변경이 일어날 가능성이 거의 없어, 해당 데이터를 조회 하기 위해 매번 DB 커넥션을 맺는 부분과 응답 시간을 개선하기 위해 Caffeine Local Cache를 적용하였습니다.

또한, Issue 및 PR이 활발하고, 비슷한 기능을 제공하는 여러 캐시 관련 제품 중 read/write 관련 성능에 충실하고, 현재 어플리케이션에서 비교적 복잡한 캐싱 기법이 필요하지 않으므로 Caffeine 선정하였습니다.

- [Caffeine 사용을 위한 의존성 추가](https://github.com/project-porko/porko-service/pull/44/commits/04e452fe9362e2c63664c4c02a5ef6b9ea6ac522)
- [CacheType 필드 기본값 설정](https://github.com/project-porko/porko-service/pull/44/commits/2570e4a552e902223311b6d76e262dbe11459231)
- [CacheManager 설정 변경](https://github.com/project-porko/porko-service/pull/44/commits/6fc451ac3ffcbb4a2fddb85278d9be28ec31e1d1)
- [CacheManager TC 작성](https://github.com/project-porko/porko-service/pull/44/commits/bcee381c0bed89688b351cc0972376f82cd94b55)
- [모든 위젯 목록 조회 로직 시 Cache 적용](https://github.com/project-porko/porko-service/pull/44/commits/19116180a979806a69dad066c1e624fff8f9ff20)

---
This closes #43 LocalCahce 적용(Caffeine)