### PR TITLE
build: PR 요청 시 TC 수행 결과 Reporting

### DIFF
--- a/.github/workflows/testReporting.yml
+++ b/.github/workflows/testReporting.yml
@@ -1,0 +1,36 @@
+name: PR Reporter # TODO: ci 적용 시, ci 과정에 tc result reporting을 포함하고 작업 이름을 변경
+
+on:
+  pull_request:
+    branches: [ develop ] # TODO: main branch PR 시 추가
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: 🍀 set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: 🍀 grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: 🍀 test with gradle
+        run: ./gradlew --info test
+
+      - name: 🍀 publish unit Test results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: 'build/test-results/**/*.xml'
+
+      - name: 🍀 add comments to fail tests
+        uses: mikepenz/action-junit-report@v3
+        if: always()
+        with:
+          report_paths: 'build/test-results/test/TEST-*.xml'


### PR DESCRIPTION
## #️⃣연관된 이슈

> #42 PR 요청 시 TC 수행 결과 Reporting

## 📝작업 내용
develop branch에 PR 요청 시, gardle을 이용한 test 수행 결과를 comment로 확인 할 수 있도록 github actions workflow를 추가하였습니다.

TC 수행 결과 reporting을 위한 Step 구성
- JDK 17 설치
- Gradle 권한 부여
- Gradle test 실행
- test 실행 reporting
  - 테스트 성공/실패 결과 comment

---
This closes #42 PR 요청 시 TC 수행 결과 Reporting
