### PR TITLE
feat: 저번 달 사용 금액 조회 기능 구현

### DIFF
--- a/porko-service/src/main/java/io/porko/budget/controller/BudgetController.java
+++ b/porko-service/src/main/java/io/porko/budget/controller/BudgetController.java
@@ -35,4 +35,9 @@ public class BudgetController {
         budgetService.setBudget(budgetRequest, id);
         return ResponseEntity.ok().build();
     }
+
+    @GetMapping("/lastused")
+    ResponseEntity<BudgetResponse> getUsedCostInLastMonth(@LoginMember Long id) {
+        return ResponseEntity.ok(budgetService.getUsedCostInLastMonth(id));
+    }
 }

--- a/porko-service/src/main/java/io/porko/budget/service/BudgetService.java
+++ b/porko-service/src/main/java/io/porko/budget/service/BudgetService.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.LocalDate;
 
 @Service
 @Transactional(readOnly = true)
@@ -38,5 +39,15 @@ public class BudgetService {
         Budget budget = budgetRequest.toEntity(id);
 
         budgetRepo.save(budget);
+    }
+
+    public BudgetResponse getUsedCostInLastMonth(Long memberId) {
+        return BudgetResponse.of(historyQueryRepo.calcUsedCostInLastMonth(
+                    LocalDate.now().getYear(),
+                    LocalDate.now().getMonthValue(),
+                    memberId)
+                .orElse(BigDecimal.ZERO)
+                .abs()
+                .stripTrailingZeros());
     }
 }

--- a/porko-service/src/main/java/io/porko/history/repo/HistoryQueryRepo.java
+++ b/porko-service/src/main/java/io/porko/history/repo/HistoryQueryRepo.java
@@ -26,4 +26,21 @@ public class HistoryQueryRepo {
                         .and(history.usedAt.dayOfMonth().lt(LocalDate.now().getDayOfMonth())))
                 .fetchOne());
     }
+
+    public Optional<BigDecimal> calcUsedCostInLastMonth (Integer currentYear, Integer currentMonth, Long memberId) {
+        if (currentMonth == 1) {
+            currentYear -= 1;
+            currentMonth = 12;
+        } else {
+            currentMonth -= 1;
+        }
+
+        return Optional.ofNullable(queryFactory.select(history.cost.sum())
+                .from(history)
+                .where(history.memberId.eq(memberId)
+                        .and(history.cost.lt(0))
+                        .and(history.usedAt.year().eq(currentYear))
+                        .and(history.usedAt.month().eq(currentMonth)))
+                .fetchOne());
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> https://github.com/project-porko/porko-service/issues/54 저번 달 사용 금액 조회 기능 구현

## 📝작업 내용
- [목표 예산 설정 API 구현](https://github.com/project-porko/porko-service/commit/0af50b7c397eb4c6150a55ec1e79cbfa3b7c9526)


- 목표 예산 설정 버튼을 클릭했을 시 요청될 기능입니다.

![image](https://github.com/project-porko/porko-service/assets/141790867/23d46e7e-84b1-4eed-ac29-7df568d492ef)
