### PR TITLE
feat: 사용자 위젯 순서 저장/변경 API

### DIFF
--- a/porko-common/src/test/java/io/porko/config/base/TestBase.java
+++ b/porko-common/src/test/java/io/porko/config/base/TestBase.java
@@ -12,8 +12,8 @@ import org.springframework.test.context.TestConstructor.AutowireMode;
 @TestConstructor(autowireMode = AutowireMode.ALL)
 public abstract class TestBase {
     static final String TEST = "test";
-    protected AtomicReference<Integer> intVariable;
-    protected AtomicReference<Long> lonVariable;
+    protected static AtomicReference<Integer> intVariable;
+    protected static AtomicReference<Long> lonVariable;
 
     @BeforeEach
     void setUp() {
@@ -21,15 +21,15 @@ public abstract class TestBase {
         lonVariable = new AtomicReference<>(1L);
     }
 
-    protected Integer nextIndex() {
+    public static Integer nextIndex() {
         return intVariable.getAndSet(intVariable.get() + 1);
     }
 
-    protected Long nextId() {
+    public Long nextId() {
         return lonVariable.getAndSet(lonVariable.get() + 1);
     }
 
-    protected Long nextId(AtomicReference<Long> lonVariable) {
+    public static Long nextId(AtomicReference<Long> lonVariable) {
         return lonVariable.getAndSet(lonVariable.get() + 1);
     }
 }

--- a/porko-common/src/test/java/io/porko/config/base/TestBase.java
+++ b/porko-common/src/test/java/io/porko/config/base/TestBase.java
@@ -2,6 +2,8 @@ package io.porko.config.base;
 
 import static io.porko.config.base.TestBase.TEST;
 
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestConstructor;
 import org.springframework.test.context.TestConstructor.AutowireMode;
@@ -10,4 +12,24 @@ import org.springframework.test.context.TestConstructor.AutowireMode;
 @TestConstructor(autowireMode = AutowireMode.ALL)
 public abstract class TestBase {
     static final String TEST = "test";
+    protected AtomicReference<Integer> intVariable;
+    protected AtomicReference<Long> lonVariable;
+
+    @BeforeEach
+    void setUp() {
+        intVariable = new AtomicReference<>(1);
+        lonVariable = new AtomicReference<>(1L);
+    }
+
+    protected Integer nextIndex() {
+        return intVariable.getAndSet(intVariable.get() + 1);
+    }
+
+    protected Long nextId() {
+        return lonVariable.getAndSet(lonVariable.get() + 1);
+    }
+
+    protected Long nextId(AtomicReference<Long> lonVariable) {
+        return lonVariable.getAndSet(lonVariable.get() + 1);
+    }
 }

--- a/porko-common/src/test/java/io/porko/config/fixture/FixtureCommon.java
+++ b/porko-common/src/test/java/io/porko/config/fixture/FixtureCommon.java
@@ -1,33 +1,33 @@
 package io.porko.config.fixture;
 
 import com.navercorp.fixturemonkey.FixtureMonkey;
-import com.navercorp.fixturemonkey.FixtureMonkeyBuilder;
 import com.navercorp.fixturemonkey.api.introspector.BuilderArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
+import com.navercorp.fixturemonkey.customizer.InnerSpec;
 import com.navercorp.fixturemonkey.jakarta.validation.plugin.JakartaValidationPlugin;
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.arbitraries.StringArbitrary;
 
 public class FixtureCommon {
-    private static final FixtureMonkeyBuilder builder = FixtureMonkey.builder();
-
     public static FixtureMonkey entityType() {
-        return builder
+        return FixtureMonkey.builder()
             .objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
             .defaultNotNull(true)
             .build();
     }
 
     public static FixtureMonkey dtoType() {
-        return builder
+        return FixtureMonkey.builder()
             .objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
             .defaultNotNull(true)
+            .plugin(new JakartaValidationPlugin())
             .build();
     }
 
     public static FixtureMonkey withValidated() {
-        return builder
+        return FixtureMonkey.builder()
+            .defaultArbitraryGenerator(UniqueArbitraryGenerator::new)
             .objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
             .defaultNotNull(true)
             .plugin(new JakartaValidationPlugin())
@@ -35,9 +35,13 @@ public class FixtureCommon {
     }
 
     public static FixtureMonkey builderType() {
-        return builder
+        return FixtureMonkey.builder()
             .objectIntrospector(BuilderArbitraryIntrospector.INSTANCE)
             .build();
+    }
+
+    public static InnerSpec setProperty(String property, Object value) {
+        return new InnerSpec().property(property, value);
     }
 
     public static StringArbitrary randomString() {

--- a/porko-common/src/test/java/io/porko/config/fixture/UniqueArbitraryGenerator.java
+++ b/porko-common/src/test/java/io/porko/config/fixture/UniqueArbitraryGenerator.java
@@ -1,0 +1,31 @@
+package io.porko.config.fixture;
+
+import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary;
+import com.navercorp.fixturemonkey.api.generator.ArbitraryGenerator;
+import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
+import java.util.HashSet;
+import java.util.Set;
+
+public class UniqueArbitraryGenerator implements ArbitraryGenerator {
+    private static final Set<Object> UNIQUE = new HashSet<>();
+
+    private final ArbitraryGenerator delegate;
+
+    public UniqueArbitraryGenerator(ArbitraryGenerator delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public CombinableArbitrary generate(ArbitraryGeneratorContext context) {
+        return delegate.generate(context)
+            .filter(
+                obj -> {
+                    if (!UNIQUE.contains(obj)) {
+                        UNIQUE.add(obj);
+                        return true;
+                    }
+                    return false;
+                }
+            );
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/service/MemberService.java
+++ b/porko-service/src/main/java/io/porko/member/service/MemberService.java
@@ -5,6 +5,7 @@ import static io.porko.member.exception.MemberErrorCode.DUPLICATED_PHONE_NUMBER;
 
 import io.porko.member.controller.model.MemberResponse;
 import io.porko.member.controller.model.signup.SignUpRequest;
+import io.porko.member.domain.Member;
 import io.porko.member.exception.MemberErrorCode;
 import io.porko.member.exception.MemberException;
 import io.porko.member.repo.MemberQueryRepo;
@@ -53,6 +54,11 @@ public class MemberService {
 
     private String encryptPassword(String password) {
         return passwordEncoder.encode(password);
+    }
+
+    public Member findMemberById(Long id) {
+        return memberRepo.findById(id)
+            .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND, id));
     }
 
     public MemberResponse loadMemberById(Long id) {

--- a/porko-service/src/main/java/io/porko/widget/controller/MemberWidgetController.java
+++ b/porko-service/src/main/java/io/porko/widget/controller/MemberWidgetController.java
@@ -1,0 +1,38 @@
+package io.porko.widget.controller;
+
+import static io.porko.widget.controller.MemberWidgetController.MEMBER_WIDGET_BASE_URI;
+
+import io.porko.auth.controller.model.LoginMember;
+import io.porko.utils.ResponseEntityUtils;
+import io.porko.widget.controller.model.ModifyMemberWidgetsOrderRequest;
+import io.porko.widget.service.MemberWidgetService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(
+    value = MEMBER_WIDGET_BASE_URI,
+    consumes = MediaType.APPLICATION_JSON_VALUE,
+    produces = MediaType.APPLICATION_JSON_VALUE
+)
+@RequiredArgsConstructor
+public class MemberWidgetController {
+    static final String MEMBER_WIDGET_BASE_URI = "/member/widget";
+    public static final String MEMBER_WIDGETS = "member/{memberId}/widgets";
+    private final MemberWidgetService memberWidgetService;
+
+    @PutMapping
+    public ResponseEntity<Void> modifyMemberWidgetOrder(
+        @LoginMember Long memberId,
+        @Valid @RequestBody ModifyMemberWidgetsOrderRequest modifyMemberWidgetsOrderRequest
+    ) {
+        memberWidgetService.reorderWidget(memberId, modifyMemberWidgetsOrderRequest);
+        return ResponseEntityUtils.created(MEMBER_WIDGETS, memberId);
+    }
+}

--- a/porko-service/src/main/java/io/porko/widget/controller/model/ModifyMemberWidgetOrderDto.java
+++ b/porko-service/src/main/java/io/porko/widget/controller/model/ModifyMemberWidgetOrderDto.java
@@ -1,0 +1,44 @@
+package io.porko.widget.controller.model;
+
+import static io.porko.widget.controller.model.ModifyMemberWidgetsOrderRequest.ORDERED_WIDGET_COUNT;
+import static io.porko.widget.exception.WidgetErrorCode.INVALID_SEQUENCE_RANGE;
+
+import io.porko.member.domain.Member;
+import io.porko.widget.domain.MemberWidget;
+import io.porko.widget.domain.Widget;
+import io.porko.widget.exception.WidgetException;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.util.Map;
+
+public record ModifyMemberWidgetOrderDto(
+    Long widgetId,
+    int sequence
+) {
+    private static final int SEQUENCE_START = 1;
+    private static final int SEQUENCE_END = ORDERED_WIDGET_COUNT;
+
+    public ModifyMemberWidgetOrderDto(
+        @NotNull @Min(2) @Max(12) Long widgetId,
+        @Min(1) @Max(6) int sequence
+    ) {
+        validateSequenceRange(sequence);
+        this.widgetId = widgetId;
+        this.sequence = sequence;
+    }
+
+    private static void validateSequenceRange(int sequence) {
+        if (isNotSequenceRange(sequence)) {
+            throw new WidgetException(INVALID_SEQUENCE_RANGE, sequence);
+        }
+    }
+
+    private static boolean isNotSequenceRange(Integer sequence) {
+        return sequence < SEQUENCE_START || sequence > SEQUENCE_END;
+    }
+
+    public MemberWidget toEntity(Member member, Map<Long, Widget> widgets) {
+        return MemberWidget.of(member, widgets.get(widgetId), sequence);
+    }
+}

--- a/porko-service/src/main/java/io/porko/widget/controller/model/ModifyMemberWidgetsOrderRequest.java
+++ b/porko-service/src/main/java/io/porko/widget/controller/model/ModifyMemberWidgetsOrderRequest.java
@@ -1,0 +1,91 @@
+package io.porko.widget.controller.model;
+
+import static io.porko.widget.exception.WidgetErrorCode.DUPLICATED_SEQUENCE;
+import static io.porko.widget.exception.WidgetErrorCode.INCLUDE_FIXED_WIDGET;
+import static io.porko.widget.exception.WidgetErrorCode.INCLUDE_NOT_EXIST_WIDGET;
+import static io.porko.widget.exception.WidgetErrorCode.INVALID_REQUEST_ORDERED_WIDGET_COUNT;
+
+import io.porko.member.domain.Member;
+import io.porko.widget.domain.OrderedMemberWidgets;
+import io.porko.widget.domain.Widget;
+import io.porko.widget.exception.WidgetException;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public record ModifyMemberWidgetsOrderRequest(
+    List<ModifyMemberWidgetOrderDto> elements
+) {
+    public static final int ORDERED_WIDGET_COUNT = 6;
+
+    public ModifyMemberWidgetsOrderRequest(@NotEmpty List<ModifyMemberWidgetOrderDto> elements) {
+        validateRequest(elements);
+        this.elements = elements;
+    }
+
+    private void validateRequest(List<ModifyMemberWidgetOrderDto> elements) {
+        validateOrderedWidgetCount(elements);
+        validateSequenceRange(elements);
+    }
+
+    private static void validateOrderedWidgetCount(List<ModifyMemberWidgetOrderDto> elements) {
+        if (elements.size() != ORDERED_WIDGET_COUNT) {
+            throw new WidgetException(INVALID_REQUEST_ORDERED_WIDGET_COUNT);
+        }
+    }
+
+    private static void validateSequenceRange(List<ModifyMemberWidgetOrderDto> elements) {
+        Set<Integer> sequenceSet = elements.stream()
+            .map(ModifyMemberWidgetOrderDto::sequence)
+            .collect(Collectors.toSet());
+
+        if (hasDuplicateSequence(sequenceSet)) {
+            throw new WidgetException(DUPLICATED_SEQUENCE, elements);
+        }
+    }
+
+    private static boolean hasDuplicateSequence(Set<Integer> sequenceSet) {
+        return sequenceSet.size() != ORDERED_WIDGET_COUNT;
+    }
+
+    public OrderedMemberWidgets toEntity(Member member, List<Widget> targetWidgets) {
+        validateTargetWidgets(targetWidgets);
+
+        Map<Long, Widget> targetWidgetMap = targetWidgets.stream()
+            .collect(Collectors.toMap(Widget::getId, widget -> widget));
+
+        return OrderedMemberWidgets.of(elements.stream()
+            .map(it -> it.toEntity(member, targetWidgetMap))
+            .collect(Collectors.toList()));
+    }
+
+    private void validateTargetWidgets(List<Widget> targetWidgets) {
+        validateIncludeFixedWidget(targetWidgets);
+        validateIncludeNotExistWidget(targetWidgets);
+    }
+
+    private static void validateIncludeFixedWidget(List<Widget> targetWidgets) {
+        Optional<Widget> fixedWidget = targetWidgets.stream()
+            .filter(it -> it.getWidgetCode().isFixed())
+            .findFirst();
+
+        if (fixedWidget.isPresent()) {
+            throw new WidgetException(INCLUDE_FIXED_WIDGET);
+        }
+    }
+
+    private void validateIncludeNotExistWidget(List<Widget> targetWidgets) {
+        if (targetWidgets.size() != ORDERED_WIDGET_COUNT) {
+            throw new WidgetException(INCLUDE_NOT_EXIST_WIDGET);
+        }
+    }
+
+    public List<Long> getWidgetIds() {
+        return elements.stream()
+            .map(ModifyMemberWidgetOrderDto::widgetId)
+            .toList();
+    }
+}

--- a/porko-service/src/main/java/io/porko/widget/controller/model/ModifyMemberWidgetsOrderRequest.java
+++ b/porko-service/src/main/java/io/porko/widget/controller/model/ModifyMemberWidgetsOrderRequest.java
@@ -83,7 +83,7 @@ public record ModifyMemberWidgetsOrderRequest(
         }
     }
 
-    public List<Long> getWidgetIds() {
+    public List<Long> extractWidgetIds() {
         return elements.stream()
             .map(ModifyMemberWidgetOrderDto::widgetId)
             .toList();

--- a/porko-service/src/main/java/io/porko/widget/controller/model/WidgetDto.java
+++ b/porko-service/src/main/java/io/porko/widget/controller/model/WidgetDto.java
@@ -1,18 +1,20 @@
 package io.porko.widget.controller.model;
 
 import io.porko.widget.domain.Widget;
+import io.porko.widget.domain.WidgetCode;
+import io.porko.widget.domain.WidgetType;
 
 public record WidgetDto(
     Long id,
-    String code,
-    String type,
+    WidgetCode code,
+    WidgetType type,
     String description
 ) {
     public static WidgetDto from(Widget widget) {
         return new WidgetDto(
             widget.getId(),
-            widget.getWidgetCode().name(),
-            widget.getWidgetCode().getType().name(),
+            widget.getWidgetCode(),
+            widget.getWidgetCode().getType(),
             widget.getWidgetCode().getDescription()
         );
     }

--- a/porko-service/src/main/java/io/porko/widget/controller/model/WidgetsResponse.java
+++ b/porko-service/src/main/java/io/porko/widget/controller/model/WidgetsResponse.java
@@ -2,6 +2,7 @@ package io.porko.widget.controller.model;
 
 import io.porko.widget.domain.Widget;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public record WidgetsResponse(
     List<WidgetDto> elements
@@ -12,5 +13,12 @@ public record WidgetsResponse(
                 .map(WidgetDto::from)
                 .toList()
         );
+    }
+
+    public List<Widget> extractByIds(List<Long> targetIds) {
+        return elements().stream()
+            .filter(widgetDto -> targetIds.contains(widgetDto.id()))
+            .map(it -> Widget.of(it.id(), it.code()))
+            .collect(Collectors.toList());
     }
 }

--- a/porko-service/src/main/java/io/porko/widget/domain/MemberWidget.java
+++ b/porko-service/src/main/java/io/porko/widget/domain/MemberWidget.java
@@ -1,0 +1,62 @@
+package io.porko.widget.domain;
+
+import io.porko.config.jpa.auditor.MetaFields;
+import io.porko.member.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(
+    uniqueConstraints = @UniqueConstraint(
+        name = "UK_MEMBER_WIDGET",
+        columnNames = {"memberId", "widgetId"}
+    )
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberWidget extends MetaFields {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(
+        name = "member_id",
+        nullable = false,
+        foreignKey = @ForeignKey(name = "FK_WIDGET_TO_MEMBER")
+    )
+    private Member member;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(
+        name = "widget_id",
+        nullable = false,
+        foreignKey = @ForeignKey(name = "FK_MEMBER_WIDGET_TO_WIDGET")
+    )
+    private Widget widget;
+
+    @Column(nullable = false)
+    private int sequence;
+
+    public MemberWidget(Member member, Widget widget, int sequence) {
+        this.member = member;
+        this.widget = widget;
+        this.sequence = sequence;
+    }
+
+    public static MemberWidget of(Member member, Widget widget, int sequence) {
+        return new MemberWidget(member, widget, sequence);
+    }
+}

--- a/porko-service/src/main/java/io/porko/widget/domain/OrderedMemberWidgets.java
+++ b/porko-service/src/main/java/io/porko/widget/domain/OrderedMemberWidgets.java
@@ -1,0 +1,40 @@
+package io.porko.widget.domain;
+
+import static io.porko.widget.exception.WidgetErrorCode.INCLUDE_FIXED_WIDGET;
+import static io.porko.widget.exception.WidgetErrorCode.INVALID_ORDERED_WIDGET_COUNT;
+
+import io.porko.widget.exception.WidgetException;
+import java.util.List;
+import java.util.Optional;
+
+public record OrderedMemberWidgets(
+    List<MemberWidget> elements
+) {
+    private static final int ORDERED_WIDGET_COUNT = 6;
+
+    public static OrderedMemberWidgets of(List<MemberWidget> memberWidgets) {
+        validateOrderedTargetWidgets(memberWidgets);
+        return new OrderedMemberWidgets(memberWidgets);
+    }
+
+    public static void validateOrderedTargetWidgets(List<MemberWidget> memberWidgets) {
+        checkIncludeFixedWidget(memberWidgets);
+        checkOrderedTargetWidgetsCount(memberWidgets);
+    }
+
+    private static void checkIncludeFixedWidget(List<MemberWidget> memberWidgets) {
+        Optional<MemberWidget> fixedWidget = memberWidgets.stream()
+            .filter(it -> it.getWidget().getWidgetCode().isFixed())
+            .findFirst();
+
+        if (fixedWidget.isPresent()) {
+            throw new WidgetException(INCLUDE_FIXED_WIDGET);
+        }
+    }
+
+    private static void checkOrderedTargetWidgetsCount(List<MemberWidget> memberWidgets) {
+        if (memberWidgets.size() != ORDERED_WIDGET_COUNT) {
+            throw new WidgetException(INVALID_ORDERED_WIDGET_COUNT);
+        }
+    }
+}

--- a/porko-service/src/main/java/io/porko/widget/domain/Widget.java
+++ b/porko-service/src/main/java/io/porko/widget/domain/Widget.java
@@ -32,7 +32,16 @@ public class Widget {
         this.widgetCode = widgetCode;
     }
 
+    public Widget(Long id, WidgetCode widgetCode) {
+        this.id = id;
+        this.widgetCode = widgetCode;
+    }
+
     public static Widget from(WidgetCode widgetCode) {
         return new Widget(widgetCode);
+    }
+
+    public static Widget of(Long id, WidgetCode widgetCode) {
+        return new Widget(id, widgetCode);
     }
 }

--- a/porko-service/src/main/java/io/porko/widget/domain/WidgetCode.java
+++ b/porko-service/src/main/java/io/porko/widget/domain/WidgetCode.java
@@ -30,4 +30,8 @@ public enum WidgetCode {
         this.type = type;
         this.description = description;
     }
+
+    public boolean isFixed() {
+        return type == FIXED;
+    }
 }

--- a/porko-service/src/main/java/io/porko/widget/exception/WidgetErrorCode.java
+++ b/porko-service/src/main/java/io/porko/widget/exception/WidgetErrorCode.java
@@ -1,0 +1,24 @@
+package io.porko.widget.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum WidgetErrorCode {
+    INCLUDE_FIXED_WIDGET(HttpStatus.BAD_REQUEST, "고정 위젯은 순서를 변경할 수 없습니다."),
+    INVALID_REQUEST_ORDERED_WIDGET_COUNT(HttpStatus.BAD_REQUEST, "순서를 변경할 6개의 위젯을 요청하세요. [request: %s]"),
+    INVALID_ORDERED_WIDGET_COUNT(HttpStatus.BAD_REQUEST, "순서 변경 시 6개의 위젯 정보가 필요합니다. 순서를 변경할 6개의 위젯을 선택하세요. [request: %s]"),
+    DUPLICATED_WIDGET(HttpStatus.BAD_REQUEST, "중복된 위젯이 포함되었습니다. [request: %s]"),
+    DUPLICATED_SEQUENCE(HttpStatus.BAD_REQUEST, "위젯 순서가 중복되었습니다.[request: %s]"),
+    INVALID_SEQUENCE_RANGE(HttpStatus.BAD_REQUEST, "1~6의 순서를 선택하세요 [request: %s]"),
+    INCLUDE_NOT_EXIST_WIDGET(HttpStatus.BAD_REQUEST, "존재하지 않는 위젯이 포함되었습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+
+    WidgetErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/porko-service/src/main/java/io/porko/widget/exception/WidgetException.java
+++ b/porko-service/src/main/java/io/porko/widget/exception/WidgetException.java
@@ -1,0 +1,25 @@
+package io.porko.widget.exception;
+
+import io.porko.exception.BusinessException;
+
+public class WidgetException extends BusinessException {
+    private WidgetErrorCode errorCode;
+    private String message;
+
+    public WidgetException(WidgetErrorCode errorCode) {
+        super(
+            errorCode.getStatus(),
+            errorCode.name(),
+            errorCode.getMessage()
+        );
+    }
+
+    public WidgetException(WidgetErrorCode errorCode, Object... args) {
+        super(
+            errorCode.getStatus(),
+            errorCode.name(),
+            errorCode.getMessage(),
+            args
+        );
+    }
+}

--- a/porko-service/src/main/java/io/porko/widget/repo/MemberWidgetRepo.java
+++ b/porko-service/src/main/java/io/porko/widget/repo/MemberWidgetRepo.java
@@ -1,0 +1,14 @@
+package io.porko.widget.repo;
+
+import io.porko.widget.domain.MemberWidget;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface MemberWidgetRepo extends JpaRepository<MemberWidget, Long> {
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Transactional
+    @Query("delete from MemberWidget m where m.member.id = :memberId")
+    void deleteByMemberId(Long memberId);
+}

--- a/porko-service/src/main/java/io/porko/widget/service/MemberWidgetService.java
+++ b/porko-service/src/main/java/io/porko/widget/service/MemberWidgetService.java
@@ -24,7 +24,7 @@ public class MemberWidgetService {
     public void reorderWidget(Long memberId, ModifyMemberWidgetsOrderRequest request) {
         Member member = memberService.findMemberById(memberId);
         WidgetsResponse widgetsResponse = widgetService.loadAllWidgets();
-        List<Widget> targetWidgets = widgetsResponse.extractByIds(request.getWidgetIds());
+        List<Widget> targetWidgets = widgetsResponse.extractByIds(request.extractWidgetIds());
 
         OrderedMemberWidgets orderedMemberWidgets = request.toEntity(member, targetWidgets);
 

--- a/porko-service/src/main/java/io/porko/widget/service/MemberWidgetService.java
+++ b/porko-service/src/main/java/io/porko/widget/service/MemberWidgetService.java
@@ -1,0 +1,34 @@
+package io.porko.widget.service;
+
+import io.porko.member.domain.Member;
+import io.porko.member.service.MemberService;
+import io.porko.widget.controller.model.ModifyMemberWidgetsOrderRequest;
+import io.porko.widget.controller.model.WidgetsResponse;
+import io.porko.widget.domain.OrderedMemberWidgets;
+import io.porko.widget.domain.Widget;
+import io.porko.widget.repo.MemberWidgetRepo;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberWidgetService {
+    private final MemberService memberService;
+    private final WidgetService widgetService;
+    private final MemberWidgetRepo memberWidgetRepo;
+
+    @Transactional
+    public void reorderWidget(Long memberId, ModifyMemberWidgetsOrderRequest request) {
+        Member member = memberService.findMemberById(memberId);
+        WidgetsResponse widgetsResponse = widgetService.loadAllWidgets();
+        List<Widget> targetWidgets = widgetsResponse.extractByIds(request.getWidgetIds());
+
+        OrderedMemberWidgets orderedMemberWidgets = request.toEntity(member, targetWidgets);
+
+        memberWidgetRepo.deleteByMemberId(memberId);
+        memberWidgetRepo.saveAll(orderedMemberWidgets.elements());
+    }
+}

--- a/porko-service/src/test/java/io/porko/widget/controller/MemberWidgetControllerTest.java
+++ b/porko-service/src/test/java/io/porko/widget/controller/MemberWidgetControllerTest.java
@@ -1,0 +1,60 @@
+package io.porko.widget.controller;
+
+import static io.porko.config.security.TestSecurityConfig.TEST_PORKO_ID;
+import static io.porko.config.security.TestSecurityConfig.TEST_PORKO_MEMBER_EMAIL;
+import static io.porko.widget.controller.MemberWidgetController.MEMBER_WIDGET_BASE_URI;
+import static io.porko.widget.fixture.MemberWidgetFixture.modifyModifyMemberWidgetsOrderRequest;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+import io.porko.config.base.presentation.WebMvcTestBase;
+import io.porko.config.security.TestSecurityConfig;
+import io.porko.widget.controller.model.ModifyMemberWidgetsOrderRequest;
+import io.porko.widget.service.MemberWidgetService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.TestExecutionEvent;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(MemberWidgetController.class)
+@DisplayName("Controller:MemberWidget")
+@Import(TestSecurityConfig.class)
+class MemberWidgetControllerTest extends WebMvcTestBase {
+    @MockBean
+    protected MemberWidgetService memberWidgetService;
+
+    @Test
+    @WithUserDetails(value = TEST_PORKO_MEMBER_EMAIL, setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @DisplayName("[회원 위젯 순서 변경][PUT:201]")
+    void modifyMemberWidgetOrder() throws Exception {
+        // Given
+        ModifyMemberWidgetsOrderRequest given = modifyModifyMemberWidgetsOrderRequest();
+        willDoNothing().given(memberWidgetService).reorderWidget(TEST_PORKO_ID, given);
+
+        // When
+        ResultActions resultActions = put()
+            .url(MEMBER_WIDGET_BASE_URI)
+            .noAuthentication()
+            .jsonContent(given)
+            .created();
+
+        // Then
+        resultActions.andDo(print());
+        verify(memberWidgetService).reorderWidget(TEST_PORKO_ID, given);
+    }
+
+    /*
+     * TODO 유효하지 못한 API 요청 TC 작성
+     *  - 변경 대상 위젯의 개수가 6개가 아닌 경우
+     *  - 변경 대상 위젯에 중복이 포함된 경우
+     *  - 변경 대상 위젯의 순서가 중복된 경우
+     *  - 변경 대상 위젯에 고정 타입 위젯이 포함된 경우
+     *  - 변경 대상 위젯의 순서가 1~6범위가 아닌 경우
+     *  - 변경 대상 위젯에 존재하지 않는 위젯이 포함된 경우
+     * */
+}

--- a/porko-service/src/test/java/io/porko/widget/controller/WidgetControllerTestHelper.java
+++ b/porko-service/src/test/java/io/porko/widget/controller/WidgetControllerTestHelper.java
@@ -18,18 +18,18 @@ public class WidgetControllerTestHelper extends WebMvcTestBase {
     public static List<Widget> widgets;
     static {
         widgets = List.of(
-            Widget.from(WidgetCode.TODAY_CONSUMPTION_WEATHER),
-            Widget.from(WidgetCode.REMAINING_BUDGET),
-            Widget.from(WidgetCode.UPCOMING_EXPENSES),
-            Widget.from(WidgetCode.LAST_MONTH_EXPENSES),
-            Widget.from(WidgetCode.CURRENT_MONTH_EXPENSES),
-            Widget.from(WidgetCode.CURRENT_MONTH_CARD_USAGE),
-            Widget.from(WidgetCode.MY_CHALLENGE),
-            Widget.from(WidgetCode.DAILY_EXPENSES),
-            Widget.from(WidgetCode.CREDIT_SCORE),
-            Widget.from(WidgetCode.INVESTMENT_RANKING),
-            Widget.from(WidgetCode.STEP_COUNT),
-            Widget.from(WidgetCode.DAILY_HOROSCOPE)
+            Widget.of(1L, WidgetCode.TODAY_CONSUMPTION_WEATHER),
+            Widget.of(2L, WidgetCode.REMAINING_BUDGET),
+            Widget.of(3L, WidgetCode.UPCOMING_EXPENSES),
+            Widget.of(4L, WidgetCode.LAST_MONTH_EXPENSES),
+            Widget.of(5L, WidgetCode.CURRENT_MONTH_EXPENSES),
+            Widget.of(6L, WidgetCode.CURRENT_MONTH_CARD_USAGE),
+            Widget.of(7L, WidgetCode.MY_CHALLENGE),
+            Widget.of(8L, WidgetCode.DAILY_EXPENSES),
+            Widget.of(9L, WidgetCode.CREDIT_SCORE),
+            Widget.of(10L, WidgetCode.INVESTMENT_RANKING),
+            Widget.of(11L, WidgetCode.STEP_COUNT),
+            Widget.of(12L, WidgetCode.DAILY_HOROSCOPE)
         );
     }
 

--- a/porko-service/src/test/java/io/porko/widget/controller/model/ModifyMemberWidgetOrderDtoTest.java
+++ b/porko-service/src/test/java/io/porko/widget/controller/model/ModifyMemberWidgetOrderDtoTest.java
@@ -1,0 +1,24 @@
+package io.porko.widget.controller.model;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import io.porko.widget.exception.WidgetErrorCode;
+import io.porko.widget.exception.WidgetException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayName("Model:ModifyMemberWidgetOrderDto")
+class ModifyMemberWidgetOrderDtoTest {
+    @ParameterizedTest
+    @ValueSource(ints = {0, 7})
+    @DisplayName("순서 범위가 1~6이 아닌 위젯이 포함된 경우")
+    void invalidSequenceRange(final int given) {
+        // When & Then
+        assertThatExceptionOfType(WidgetException.class)
+            .isThrownBy(() -> new ModifyMemberWidgetOrderDto(1L, given))
+            .extracting(WidgetException::getCode)
+            .isEqualTo(WidgetErrorCode.INVALID_SEQUENCE_RANGE.name())
+        ;
+    }
+}

--- a/porko-service/src/test/java/io/porko/widget/controller/model/ModifyMemberWidgetsOrderRequestTest.java
+++ b/porko-service/src/test/java/io/porko/widget/controller/model/ModifyMemberWidgetsOrderRequestTest.java
@@ -1,0 +1,145 @@
+package io.porko.widget.controller.model;
+
+import static io.porko.config.fixture.FixtureCommon.dtoType;
+import static io.porko.config.fixture.FixtureCommon.entityType;
+import static io.porko.widget.controller.WidgetControllerTestHelper.widgetsResponse;
+import static io.porko.widget.controller.model.ModifyMemberWidgetsOrderRequest.ORDERED_WIDGET_COUNT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import com.navercorp.fixturemonkey.ArbitraryBuilder;
+import io.porko.config.base.TestBase;
+import io.porko.member.domain.Member;
+import io.porko.widget.domain.MemberWidget;
+import io.porko.widget.domain.OrderedMemberWidgets;
+import io.porko.widget.domain.Widget;
+import io.porko.widget.exception.WidgetErrorCode;
+import io.porko.widget.exception.WidgetException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+// TODO: 테스트가 어려운 해당 Class의 설계가 잘 못되진 않았는지 고민 후 리팩토링
+@DisplayName("Model:Request:ModifyMemberWidgetsOrder")
+class ModifyMemberWidgetsOrderRequestTest extends TestBase {
+    private final ArbitraryBuilder<ModifyMemberWidgetOrderDto> givenBuilder = dtoType()
+        .giveMeBuilder(ModifyMemberWidgetOrderDto.class);
+
+    private final ArbitraryBuilder<Widget> widgetBuilder = dtoType()
+        .giveMeBuilder(Widget.class);
+
+    @Nested
+    @DisplayName("회원의 위젯 순서 변경 요청 시 예외 발생")
+    class ExceptionTest {
+        @Test
+        @DisplayName("순서를 변경할 위젯의 개수가 6개가 아닌 경우")
+        void invalidCount() {
+            // When & Then
+            assertThatExceptionOfType(WidgetException.class)
+                .isThrownBy(() -> new ModifyMemberWidgetsOrderRequest(givenBuilder.sampleList(1)))
+                .extracting(WidgetException::getCode)
+                .isEqualTo(WidgetErrorCode.INVALID_REQUEST_ORDERED_WIDGET_COUNT.name())
+            ;
+        }
+
+        @Test
+        @DisplayName("중복된 순서를 가진 위젯이 포함된 경우")
+        void duplicatedSequence() {
+            // Given
+            List<ModifyMemberWidgetOrderDto> given = givenBuilder
+                .set("sequence", 1, 2)
+                .sampleList(ORDERED_WIDGET_COUNT);
+
+            // When & Then
+            assertThatExceptionOfType(WidgetException.class)
+                .isThrownBy(() -> new ModifyMemberWidgetsOrderRequest(given))
+                .extracting(WidgetException::getCode)
+                .isEqualTo(WidgetErrorCode.DUPLICATED_SEQUENCE.name())
+            ;
+        }
+
+        @Test
+        @DisplayName("순서를 변경할 위젯 목록에 고정 타입의 위젯이 포함된 경우")
+        void includeFixedTypeWidget() {
+            // Given
+            Member member = entityType().giveMeOne(Member.class);
+
+            List<ModifyMemberWidgetOrderDto> targetWidget = givenBuilder
+                .setLazy("widgetId", () -> nextId())
+                .setLazy("sequence", () -> nextIndex())
+                .sampleList(ORDERED_WIDGET_COUNT);
+
+            List<Long> collect = targetWidget.stream()
+                .map(it -> it.widgetId())
+                .collect(Collectors.toList());
+
+            List<Widget> fromWidgets = widgetsResponse.extractByIds(collect);
+
+            ModifyMemberWidgetsOrderRequest given = new ModifyMemberWidgetsOrderRequest(targetWidget);
+
+            // When & Then
+            assertThatExceptionOfType(WidgetException.class)
+                .isThrownBy(() -> given.toEntity(member, fromWidgets))
+                .extracting(WidgetException::getCode)
+                .isEqualTo(WidgetErrorCode.INCLUDE_FIXED_WIDGET.name())
+            ;
+        }
+
+        @Test
+        @DisplayName("순서를 변경할 위젯 목록에 존재하지 않는 위젯이 포함된 경우")
+        void IncludeNotExistWidget() {
+            // Given
+            Member member = entityType().giveMeOne(Member.class);
+            AtomicReference<Long> longAtomicReference = new AtomicReference<>(8L);
+            List<ModifyMemberWidgetOrderDto> targetWidgets = givenBuilder
+                .setLazy("widgetId", () -> nextId(longAtomicReference))
+                .setLazy("sequence", () -> nextIndex())
+                .sampleList(ORDERED_WIDGET_COUNT);
+
+            List<Long> targetWidgetIds = targetWidgets.stream().map(it -> it.widgetId()).collect(Collectors.toList());
+            List<Widget> widgets = widgetsResponse.extractByIds(targetWidgetIds);
+
+            ModifyMemberWidgetsOrderRequest given = new ModifyMemberWidgetsOrderRequest(targetWidgets);
+
+            // When & Then
+            assertThatExceptionOfType(WidgetException.class)
+                .isThrownBy(() -> given.toEntity(member, widgets))
+                .extracting(WidgetException::getCode)
+                .isEqualTo(WidgetErrorCode.INCLUDE_NOT_EXIST_WIDGET.name())
+            ;
+        }
+    }
+
+    @Test
+    @DisplayName("회원의 위젯 순서 변경 요청 시 순서가 지정된 위젯으로 변경")
+    void toEntity() {
+        // Given
+        Member member = entityType().giveMeOne(Member.class);
+        AtomicReference<Long> longAtomicReference = new AtomicReference<>(2L);
+
+        List<ModifyMemberWidgetOrderDto> targetWidgets = givenBuilder
+            .setLazy("widgetId", () -> nextId(longAtomicReference))
+            .setLazy("sequence", () -> nextIndex())
+            .sampleList(ORDERED_WIDGET_COUNT);
+
+        List<Long> targetWidgetIds = targetWidgets.stream().map(it -> it.widgetId()).collect(Collectors.toList());
+        List<Integer> expected = targetWidgets.stream().map(it -> it.sequence()).collect(Collectors.toList());
+
+        List<Widget> widgets = widgetsResponse.extractByIds(targetWidgetIds);
+
+        // When
+        ModifyMemberWidgetsOrderRequest given = new ModifyMemberWidgetsOrderRequest(targetWidgets);
+        OrderedMemberWidgets actual = given.toEntity(member, widgets);
+
+        // Then
+        List<Integer> actualSequences = actual.elements()
+            .stream()
+            .map(MemberWidget::getSequence)
+            .collect(Collectors.toList());
+
+        assertThat(actualSequences).isEqualTo(expected);
+    }
+}

--- a/porko-service/src/test/java/io/porko/widget/controller/model/ModifyMemberWidgetsOrderRequestTest.java
+++ b/porko-service/src/test/java/io/porko/widget/controller/model/ModifyMemberWidgetsOrderRequestTest.java
@@ -4,6 +4,7 @@ import static io.porko.config.fixture.FixtureCommon.dtoType;
 import static io.porko.config.fixture.FixtureCommon.entityType;
 import static io.porko.widget.controller.WidgetControllerTestHelper.widgetsResponse;
 import static io.porko.widget.controller.model.ModifyMemberWidgetsOrderRequest.ORDERED_WIDGET_COUNT;
+import static io.porko.widget.fixture.MemberWidgetFixture.targetWidgets;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
@@ -118,12 +119,7 @@ class ModifyMemberWidgetsOrderRequestTest extends TestBase {
     void toEntity() {
         // Given
         Member member = entityType().giveMeOne(Member.class);
-        AtomicReference<Long> longAtomicReference = new AtomicReference<>(2L);
-
-        List<ModifyMemberWidgetOrderDto> targetWidgets = givenBuilder
-            .setLazy("widgetId", () -> nextId(longAtomicReference))
-            .setLazy("sequence", () -> nextIndex())
-            .sampleList(ORDERED_WIDGET_COUNT);
+        List<ModifyMemberWidgetOrderDto> targetWidgets = targetWidgets();
 
         List<Long> targetWidgetIds = targetWidgets.stream().map(it -> it.widgetId()).collect(Collectors.toList());
         List<Integer> expected = targetWidgets.stream().map(it -> it.sequence()).collect(Collectors.toList());

--- a/porko-service/src/test/java/io/porko/widget/fixture/MemberWidgetFixture.java
+++ b/porko-service/src/test/java/io/porko/widget/fixture/MemberWidgetFixture.java
@@ -1,0 +1,27 @@
+package io.porko.widget.fixture;
+
+import static io.porko.config.base.TestBase.nextId;
+import static io.porko.config.base.TestBase.nextIndex;
+import static io.porko.config.fixture.FixtureCommon.dtoType;
+import static io.porko.widget.controller.model.ModifyMemberWidgetsOrderRequest.ORDERED_WIDGET_COUNT;
+
+import io.porko.widget.controller.model.ModifyMemberWidgetOrderDto;
+import io.porko.widget.controller.model.ModifyMemberWidgetsOrderRequest;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class MemberWidgetFixture {
+    public static ModifyMemberWidgetsOrderRequest modifyModifyMemberWidgetsOrderRequest() {
+        return new ModifyMemberWidgetsOrderRequest(targetWidgets());
+    }
+
+    public static List<ModifyMemberWidgetOrderDto> targetWidgets() {
+        AtomicReference<Long> longAtomicReference = new AtomicReference<>(2L);
+
+        return dtoType()
+            .giveMeBuilder(ModifyMemberWidgetOrderDto.class)
+            .setLazy("widgetId", () -> nextId(longAtomicReference))
+            .setLazy("sequence", () -> nextIndex())
+            .sampleList(ORDERED_WIDGET_COUNT);
+    }
+}

--- a/porko-service/src/test/java/io/porko/widget/service/MemberWidgetServiceTest.java
+++ b/porko-service/src/test/java/io/porko/widget/service/MemberWidgetServiceTest.java
@@ -1,0 +1,71 @@
+package io.porko.widget.service;
+
+import static io.porko.config.fixture.FixtureCommon.dtoType;
+import static io.porko.config.fixture.FixtureCommon.withValidated;
+import static io.porko.config.security.TestSecurityConfig.testMember;
+import static io.porko.widget.controller.WidgetControllerTestHelper.widgetsResponse;
+import static io.porko.widget.controller.model.ModifyMemberWidgetsOrderRequest.ORDERED_WIDGET_COUNT;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.verify;
+
+import io.porko.config.base.business.ServiceTestBase;
+import io.porko.member.service.MemberService;
+import io.porko.widget.controller.model.ModifyMemberWidgetOrderDto;
+import io.porko.widget.controller.model.ModifyMemberWidgetsOrderRequest;
+import io.porko.widget.repo.MemberWidgetRepo;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+@DisplayName("Service:MemberWidget")
+class MemberWidgetServiceTest extends ServiceTestBase {
+    @Mock
+    MemberService memberService;
+
+    @Mock
+    WidgetService widgetService;
+
+    @Mock
+    MemberWidgetRepo memberWidgetRepo;
+
+    @InjectMocks
+    MemberWidgetService memberWidgetService;
+
+    @Disabled
+    @Test
+    @DisplayName("회원 위젯 순서 변경")
+    void reorderWidget() {
+        // Given
+        final Long memberId = 1L;
+        given(memberService.findMemberById(memberId)).willReturn(testMember);
+        given(widgetService.loadAllWidgets()).willReturn(widgetsResponse);
+
+        willDoNothing().given(memberWidgetRepo).deleteByMemberId(memberId);
+        given(memberWidgetRepo.saveAll(anyCollection())).willReturn(null);
+
+        AtomicReference<Long> longAtomicReference = new AtomicReference<>(2L);
+
+        List<ModifyMemberWidgetOrderDto> targetWidgets = dtoType()
+            .giveMeBuilder(ModifyMemberWidgetOrderDto.class)
+            .setLazy("widgetId", () -> nextId(longAtomicReference))
+            .setLazy("sequence", () -> nextIndex())
+            .sampleList(ORDERED_WIDGET_COUNT);
+        
+        ModifyMemberWidgetsOrderRequest given = new ModifyMemberWidgetsOrderRequest(targetWidgets);
+
+        // When
+        memberWidgetService.reorderWidget(memberId, given);
+
+        // Then
+        verify(memberService).findMemberById(memberId);
+        verify(widgetService).loadAllWidgets();
+        verify(memberWidgetRepo).deleteByMemberId(memberId);
+        verify(memberWidgetRepo).saveAll(anyCollection());
+    }
+}

--- a/porko-service/src/test/java/io/porko/widget/service/MemberWidgetServiceTest.java
+++ b/porko-service/src/test/java/io/porko/widget/service/MemberWidgetServiceTest.java
@@ -1,10 +1,8 @@
 package io.porko.widget.service;
 
-import static io.porko.config.fixture.FixtureCommon.dtoType;
-import static io.porko.config.fixture.FixtureCommon.withValidated;
 import static io.porko.config.security.TestSecurityConfig.testMember;
 import static io.porko.widget.controller.WidgetControllerTestHelper.widgetsResponse;
-import static io.porko.widget.controller.model.ModifyMemberWidgetsOrderRequest.ORDERED_WIDGET_COUNT;
+import static io.porko.widget.fixture.MemberWidgetFixture.modifyModifyMemberWidgetsOrderRequest;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
@@ -12,12 +10,8 @@ import static org.mockito.Mockito.verify;
 
 import io.porko.config.base.business.ServiceTestBase;
 import io.porko.member.service.MemberService;
-import io.porko.widget.controller.model.ModifyMemberWidgetOrderDto;
 import io.porko.widget.controller.model.ModifyMemberWidgetsOrderRequest;
 import io.porko.widget.repo.MemberWidgetRepo;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -37,7 +31,6 @@ class MemberWidgetServiceTest extends ServiceTestBase {
     @InjectMocks
     MemberWidgetService memberWidgetService;
 
-    @Disabled
     @Test
     @DisplayName("회원 위젯 순서 변경")
     void reorderWidget() {
@@ -49,15 +42,7 @@ class MemberWidgetServiceTest extends ServiceTestBase {
         willDoNothing().given(memberWidgetRepo).deleteByMemberId(memberId);
         given(memberWidgetRepo.saveAll(anyCollection())).willReturn(null);
 
-        AtomicReference<Long> longAtomicReference = new AtomicReference<>(2L);
-
-        List<ModifyMemberWidgetOrderDto> targetWidgets = dtoType()
-            .giveMeBuilder(ModifyMemberWidgetOrderDto.class)
-            .setLazy("widgetId", () -> nextId(longAtomicReference))
-            .setLazy("sequence", () -> nextIndex())
-            .sampleList(ORDERED_WIDGET_COUNT);
-        
-        ModifyMemberWidgetsOrderRequest given = new ModifyMemberWidgetsOrderRequest(targetWidgets);
+        ModifyMemberWidgetsOrderRequest given = modifyModifyMemberWidgetsOrderRequest();
 
         // When
         memberWidgetService.reorderWidget(memberId, given);

--- a/porko-service/src/test/java/io/porko/widget/service/WidgetServiceTest.java
+++ b/porko-service/src/test/java/io/porko/widget/service/WidgetServiceTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.verify;
 import io.porko.config.base.TestBase;
 import io.porko.config.cache.CacheConfig;
 import io.porko.config.cache.CacheType;
-import io.porko.widget.controller.model.WidgetsResponse;
 import io.porko.widget.repo.WidgetRepo;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -43,10 +42,7 @@ class WidgetServiceTest extends TestBase {
         given(widgetRepo.findAll()).willReturn(widgets);
 
         // When
-        repeat(repeatCount, () -> {
-            WidgetsResponse widgetsResponse = widgetService.loadAllWidgets();
-            System.out.println(widgetsResponse);
-        });
+        repeat(repeatCount, widgetService::loadAllWidgets);
 
         // Then
         verify(cacheManager, times(repeatCount)).getCache(CacheType.WIDGETS.getName());


### PR DESCRIPTION
## #️⃣연관된 이슈

> #40 사용자 위젯 순서 저장/변경 API

## 📝작업 내용
사용자 홈 화면의 각 위젯 순서를 저장/변경 하는 API입니다. 사용자가 설정한 순서가 지정된 위젯 목록을 입력 받아 기존 저장된 위젯 순서 목록을 지우고 요청 받은 내용으로 초기화 합니다.  사용자 요청 위젯은 DB를 통해 조회 하지 않고 Local Cache에 저장된 위젯 목록에서 추출하였습니다.


- [사용자 위젯 Entity 정의](https://github.com/project-porko/porko-service/commit/a3034a2920581d16b95407422cc9b5fd60ce5c62)
- [사용자 위젯 순서 변경 서비스 구현](https://github.com/project-porko/porko-service/commit/fdbeea7b9c053481e28fdc5cdfc8dd1df45c259d)
-[회원 위젯 순서 변경 Controller 구현 및 TC 작성](https://github.com/project-porko/porko-service/commit/287d74ab8d5644a134fd53adbb061b6e596c5138)

---
This closes #40 사용자 위젯 순서 저장/변경 API