### PR TITLE
feat: 생성/수정자의 메타데이터 주입을 위한 Jpa Auditor Aware 설정

### DIFF
--- a/porko-common/src/main/java/io/porko/config/jpa/JpaConfig.java
+++ b/porko-common/src/main/java/io/porko/config/jpa/JpaConfig.java
@@ -1,9 +1,0 @@
-package io.porko.config.jpa;
-
-import org.springframework.context.annotation.Configuration;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-
-@Configuration
-@EnableJpaAuditing(modifyOnCreate = false)
-public class JpaConfig {
-}

--- a/porko-service/src/main/java/io/porko/config/jpa/JpaConfig.java
+++ b/porko-service/src/main/java/io/porko/config/jpa/JpaConfig.java
@@ -1,0 +1,35 @@
+package io.porko.config.jpa;
+
+import static org.springframework.security.config.Elements.ANONYMOUS;
+
+import io.porko.auth.controller.model.PorkoPrincipal;
+import java.util.Optional;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@Configuration
+@EnableJpaAuditing(modifyOnCreate = false)
+public class JpaConfig {
+    @Bean
+    public AuditorAware<Long> auditorAware() {
+        return () -> Optional.of(SecurityContextHolder.getContext())
+            .map(SecurityContext::getAuthentication)
+            .filter(this::isAuthenticated)
+            .map(Authentication::getPrincipal)
+            .map(PorkoPrincipal.class::cast)
+            .map(PorkoPrincipal::getId);
+    }
+
+    private boolean isAuthenticated(Authentication authentication) {
+        return authentication.isAuthenticated() && isNotAnonymousUser(authentication);
+    }
+
+    private boolean isNotAnonymousUser(Authentication authentication) {
+        return !authentication.getName().contains(ANONYMOUS);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #51 JPA AuditorAware 설정

## 📝작업 내용
인증된 사용자 정보가 저장된 SecurityContextHolder에서 CreatedBy/UpdatedBy에 해당하는 회원 번호 추출 및 설정 부 구현

- [생성/수정자의 메타데이터 주입을 위한 Jpa Auditor Aware 설정](https://github.com/project-porko/porko-service/commit/c8bbc222921313711c1420af9e156b2de5329ebd)

---
This closes #51 JPA AuditorAware 설정