### PR TITLE
feat: 사용자 위젯 순서 조회 API

### DIFF
--- a/porko-service/src/main/java/io/porko/widget/controller/MemberWidgetController.java
+++ b/porko-service/src/main/java/io/porko/widget/controller/MemberWidgetController.java
@@ -5,11 +5,13 @@ import static io.porko.widget.controller.MemberWidgetController.MEMBER_WIDGET_BA
 import io.porko.auth.controller.model.LoginMember;
 import io.porko.utils.ResponseEntityUtils;
 import io.porko.widget.controller.model.ModifyMemberWidgetsOrderRequest;
+import io.porko.widget.controller.model.OrderedMemberWidgetsResponse;
 import io.porko.widget.service.MemberWidgetService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,5 +36,12 @@ public class MemberWidgetController {
     ) {
         memberWidgetService.reorderWidget(memberId, modifyMemberWidgetsOrderRequest);
         return ResponseEntityUtils.created(MEMBER_WIDGETS, memberId);
+    }
+
+    @GetMapping
+    public ResponseEntity<OrderedMemberWidgetsResponse> getOrderedMemberWidget(
+        @LoginMember Long memberId
+    ) {
+        return ResponseEntity.ok(memberWidgetService.loadOrderedMemberWidgets(memberId));
     }
 }

--- a/porko-service/src/main/java/io/porko/widget/controller/model/OrderedMemberWidgetsDto.java
+++ b/porko-service/src/main/java/io/porko/widget/controller/model/OrderedMemberWidgetsDto.java
@@ -1,0 +1,20 @@
+package io.porko.widget.controller.model;
+
+import io.porko.widget.domain.MemberWidget;
+import io.porko.widget.domain.WidgetCode;
+
+public record OrderedMemberWidgetsDto(
+    Long id,
+    WidgetCode code,
+    String description,
+    int sequence
+) {
+    public static OrderedMemberWidgetsDto from(MemberWidget memberWidget) {
+        return new OrderedMemberWidgetsDto(
+            memberWidget.getId(),
+            memberWidget.getWidgetCode(),
+            memberWidget.getWidgetDescription(),
+            memberWidget.getSequence()
+        );
+    }
+}

--- a/porko-service/src/main/java/io/porko/widget/controller/model/OrderedMemberWidgetsResponse.java
+++ b/porko-service/src/main/java/io/porko/widget/controller/model/OrderedMemberWidgetsResponse.java
@@ -1,0 +1,15 @@
+package io.porko.widget.controller.model;
+
+import io.porko.widget.domain.MemberWidget;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record OrderedMemberWidgetsResponse(
+    List<OrderedMemberWidgetsDto> elements
+) {
+    public static OrderedMemberWidgetsResponse from(List<MemberWidget> orderedMemberWidget) {
+        return new OrderedMemberWidgetsResponse(orderedMemberWidget.stream()
+            .map(OrderedMemberWidgetsDto::from)
+            .collect(Collectors.toList()));
+    }
+}

--- a/porko-service/src/main/java/io/porko/widget/domain/MemberWidget.java
+++ b/porko-service/src/main/java/io/porko/widget/domain/MemberWidget.java
@@ -59,4 +59,12 @@ public class MemberWidget extends MetaFields {
     public static MemberWidget of(Member member, Widget widget, int sequence) {
         return new MemberWidget(member, widget, sequence);
     }
+
+    public WidgetCode getWidgetCode() {
+        return widget.getWidgetCode();
+    }
+
+    public String getWidgetDescription() {
+        return widget.getDescription();
+    }
 }

--- a/porko-service/src/main/java/io/porko/widget/domain/Widget.java
+++ b/porko-service/src/main/java/io/porko/widget/domain/Widget.java
@@ -44,4 +44,12 @@ public class Widget {
     public static Widget of(Long id, WidgetCode widgetCode) {
         return new Widget(id, widgetCode);
     }
+
+    public WidgetType getWidgetType() {
+        return widgetCode.getType();
+    }
+
+    public String getDescription() {
+        return widgetCode.getDescription();
+    }
 }

--- a/porko-service/src/main/java/io/porko/widget/repo/MemberWidgetRepo.java
+++ b/porko-service/src/main/java/io/porko/widget/repo/MemberWidgetRepo.java
@@ -1,6 +1,7 @@
 package io.porko.widget.repo;
 
 import io.porko.widget.domain.MemberWidget;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -11,4 +12,6 @@ public interface MemberWidgetRepo extends JpaRepository<MemberWidget, Long> {
     @Transactional
     @Query("delete from MemberWidget m where m.member.id = :memberId")
     void deleteByMemberId(Long memberId);
+
+    List<MemberWidget> findByMemberIdOrderBySequenceAsc(Long id);
 }

--- a/porko-service/src/main/java/io/porko/widget/service/MemberWidgetService.java
+++ b/porko-service/src/main/java/io/porko/widget/service/MemberWidgetService.java
@@ -3,6 +3,7 @@ package io.porko.widget.service;
 import io.porko.member.domain.Member;
 import io.porko.member.service.MemberService;
 import io.porko.widget.controller.model.ModifyMemberWidgetsOrderRequest;
+import io.porko.widget.controller.model.OrderedMemberWidgetsResponse;
 import io.porko.widget.controller.model.WidgetsResponse;
 import io.porko.widget.domain.OrderedMemberWidgets;
 import io.porko.widget.domain.Widget;
@@ -30,5 +31,9 @@ public class MemberWidgetService {
 
         memberWidgetRepo.deleteByMemberId(memberId);
         memberWidgetRepo.saveAll(orderedMemberWidgets.elements());
+    }
+
+    public OrderedMemberWidgetsResponse loadOrderedMemberWidgets(Long memberId) {
+        return OrderedMemberWidgetsResponse.from(memberWidgetRepo.findByMemberIdOrderBySequenceAsc(memberId));
     }
 }

--- a/porko-service/src/test/java/io/porko/widget/controller/MemberWidgetControllerTest.java
+++ b/porko-service/src/test/java/io/porko/widget/controller/MemberWidgetControllerTest.java
@@ -4,13 +4,16 @@ import static io.porko.config.security.TestSecurityConfig.TEST_PORKO_ID;
 import static io.porko.config.security.TestSecurityConfig.TEST_PORKO_MEMBER_EMAIL;
 import static io.porko.widget.controller.MemberWidgetController.MEMBER_WIDGET_BASE_URI;
 import static io.porko.widget.fixture.MemberWidgetFixture.modifyModifyMemberWidgetsOrderRequest;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
 import io.porko.config.base.presentation.WebMvcTestBase;
+import io.porko.config.fixture.FixtureCommon;
 import io.porko.config.security.TestSecurityConfig;
 import io.porko.widget.controller.model.ModifyMemberWidgetsOrderRequest;
+import io.porko.widget.controller.model.OrderedMemberWidgetsResponse;
 import io.porko.widget.service.MemberWidgetService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -57,4 +60,22 @@ class MemberWidgetControllerTest extends WebMvcTestBase {
      *  - 변경 대상 위젯의 순서가 1~6범위가 아닌 경우
      *  - 변경 대상 위젯에 존재하지 않는 위젯이 포함된 경우
      * */
+
+    @Test
+    @WithUserDetails(value = TEST_PORKO_MEMBER_EMAIL, setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @DisplayName("[회원 위젯 순서 조회][GET:200]")
+    void getOrderedMemberWidget() throws Exception {
+        OrderedMemberWidgetsResponse given = FixtureCommon.dtoType().giveMeBuilder(OrderedMemberWidgetsResponse.class).sample();
+
+        // Given
+        given(memberWidgetService.loadOrderedMemberWidgets(TEST_PORKO_ID)).willReturn(given);
+
+        // When
+        get()
+            .url("/member/widget")
+            .noAuthentication()
+            .expect().ok();
+
+        // Then
+    }
 }

--- a/porko-service/src/test/java/io/porko/widget/service/MemberWidgetServiceTest.java
+++ b/porko-service/src/test/java/io/porko/widget/service/MemberWidgetServiceTest.java
@@ -1,5 +1,6 @@
 package io.porko.widget.service;
 
+import static io.porko.config.security.TestSecurityConfig.TEST_PORKO_ID;
 import static io.porko.config.security.TestSecurityConfig.testMember;
 import static io.porko.widget.controller.WidgetControllerTestHelper.widgetsResponse;
 import static io.porko.widget.fixture.MemberWidgetFixture.modifyModifyMemberWidgetsOrderRequest;
@@ -8,10 +9,14 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.verify;
 
+import com.navercorp.fixturemonkey.api.type.TypeReference;
 import io.porko.config.base.business.ServiceTestBase;
+import io.porko.config.fixture.FixtureCommon;
 import io.porko.member.service.MemberService;
 import io.porko.widget.controller.model.ModifyMemberWidgetsOrderRequest;
+import io.porko.widget.domain.MemberWidget;
 import io.porko.widget.repo.MemberWidgetRepo;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -52,5 +57,23 @@ class MemberWidgetServiceTest extends ServiceTestBase {
         verify(widgetService).loadAllWidgets();
         verify(memberWidgetRepo).deleteByMemberId(memberId);
         verify(memberWidgetRepo).saveAll(anyCollection());
+    }
+
+    @Test
+    @DisplayName("회원 위젯 순서 조회")
+    void loadOrderedMemberWidgets() {
+        // Given
+        List<MemberWidget> sample = FixtureCommon.entityType()
+            .giveMeBuilder(new TypeReference<List<MemberWidget>>() {
+            })
+            .sample();
+
+        given(memberWidgetRepo.findByMemberIdOrderBySequenceAsc(TEST_PORKO_ID)).willReturn(sample);
+
+        // When
+        memberWidgetService.loadOrderedMemberWidgets(TEST_PORKO_ID);
+
+        // Then
+        verify(memberWidgetRepo).findByMemberIdOrderBySequenceAsc(TEST_PORKO_ID);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #61 사용자 위젯 순서 조회 API

## 📝작업 내용
순서가 지정된 사용자 위젯 목록 조회 API 입니다. 조회 시 application property에 적용된 global batch size를 이용하여 MemberWidget과 @OneToMany 관계를 가지는 widget 테이블 조회 시 in절로 조회할 수 있도록 구현하였습니다.

반환 시 위젯 순서 내림차순으로 정렬하여 응답 데이터를 반환합니다.

---
This closes #61 사용자 위젯 순서 조회 API