### PR TITLE
feat: 일별/주차별/월별 수입/지출 계산 쿼리 작성

### DIFF
--- a/porko-service/src/main/java/io/porko/history/domain/History.java
+++ b/porko-service/src/main/java/io/porko/history/domain/History.java
@@ -1,0 +1,80 @@
+package io.porko.history.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class History {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @Column(nullable = false)
+    private BigDecimal cost;
+
+    @Column(nullable = false)
+    private Boolean regret;
+
+    @Column(nullable = false, length = 30)
+    private String place;
+
+    @Column(nullable = false, length = 30)
+    private String payType;
+
+    @Column(nullable = false)
+    private LocalDateTime usedAt;
+
+    @Embedded
+    private SpendingCategory spendingCategoryId;
+
+    @Column(nullable = false)
+    private Type type;
+
+    @Column(length = 100)
+    private String memo;
+
+    public History(
+            Long memberId,
+            BigDecimal cost,
+            Boolean regret,
+            String place,
+            String payType,
+            LocalDateTime usedAt,
+            SpendingCategory spendingCategoryId,
+            Type type,
+            String memo
+    ) {
+        this.memberId = memberId;
+        this.cost = cost;
+        this.regret = regret;
+        this.place = place;
+        this.payType = payType;
+        this.usedAt = usedAt;
+        this.spendingCategoryId = spendingCategoryId;
+        this.type = type;
+        this.memo = memo;
+    }
+
+    public static History of(
+            Long memberId,
+            BigDecimal cost,
+            Boolean regret,
+            String place,
+            String payType,
+            LocalDateTime usedAt,
+            SpendingCategory spendingCategoryId,
+            Type type,
+            String memo
+    ) {
+        return new History(memberId, cost, regret, place, payType, usedAt, spendingCategoryId, type, memo);
+    }
+}

--- a/porko-service/src/main/java/io/porko/history/domain/SpendingCategory.java
+++ b/porko-service/src/main/java/io/porko/history/domain/SpendingCategory.java
@@ -1,0 +1,31 @@
+package io.porko.history.domain;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.AccessType;
+import org.springframework.data.annotation.AccessType.Type;
+
+@Getter
+@Embeddable
+@AccessType(Type.FIELD)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SpendingCategory {
+    @Id
+    @GeneratedValue (strategy = GenerationType.IDENTITY)
+    private Long categoryId;
+    private String name;
+    private String url;
+
+    private SpendingCategory (String name, String url) {
+        this.name = name;
+        this.url = url;
+    }
+    public static SpendingCategory of(String name, String url) {
+        return new SpendingCategory(name, url);
+    }
+}

--- a/porko-service/src/main/java/io/porko/history/domain/Type.java
+++ b/porko-service/src/main/java/io/porko/history/domain/Type.java
@@ -1,0 +1,5 @@
+package io.porko.history.domain;
+
+public enum Type {
+    수입,지출,이체
+}

--- a/porko-service/src/main/java/io/porko/history/repo/HistoryQueryRepo.java
+++ b/porko-service/src/main/java/io/porko/history/repo/HistoryQueryRepo.java
@@ -6,7 +6,8 @@ import org.springframework.stereotype.Repository;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.YearMonth;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Optional;
 
 import static io.porko.history.domain.QHistory.history;
@@ -41,6 +42,52 @@ public class HistoryQueryRepo {
                         .and(history.cost.lt(0))
                         .and(history.usedAt.year().eq(currentYear))
                         .and(history.usedAt.month().eq(currentMonth)))
+                .fetchOne());
+    }
+
+    public Optional<BigDecimal> calcDailyUsedCost (LocalDate date, Long memberId) {
+        return Optional.ofNullable(queryFactory.select(history.cost.sum())
+                .from(history)
+                .where(history.memberId.eq(memberId)
+                        .and(history.cost.lt(0))
+                        .and(history.usedAt.year().eq(date.getYear()))
+                        .and(history.usedAt.month().eq(date.getMonthValue()))
+                        .and(history.usedAt.dayOfMonth().eq(date.getDayOfMonth())))
+                .fetchOne());
+    }
+
+    public Optional<BigDecimal> calcDailyEarnedCost (LocalDate date, Long memberId) {
+        return Optional.ofNullable(queryFactory.select(history.cost.sum())
+                .from(history)
+                .where(history.memberId.eq(memberId)
+                        .and(history.cost.gt(0))
+                        .and(history.usedAt.year().eq(date.getYear()))
+                        .and(history.usedAt.month().eq(date.getMonthValue()))
+                        .and(history.usedAt.dayOfMonth().eq(date.getDayOfMonth())))
+                .fetchOne());
+    }
+
+    public Optional<BigDecimal> calcUsedCostForPeriod (LocalDate startDate, LocalDate endDate, Long memberId) {
+        LocalDateTime startDateTime = LocalDateTime.of(startDate, LocalTime.MIN);
+        LocalDateTime endDateTime = LocalDateTime.of(endDate, LocalTime.MAX);
+
+        return Optional.ofNullable(queryFactory.select(history.cost.sum())
+                .from(history)
+                .where(history.memberId.eq(memberId)
+                        .and(history.cost.lt(0))
+                        .and(history.usedAt.between(startDateTime, endDateTime)))
+                .fetchOne());
+    }
+
+    public Optional<BigDecimal> calcEarnedCostForPeriod (LocalDate startDate, LocalDate endDate, Long memberId) {
+        LocalDateTime startDateTime = LocalDateTime.of(startDate, LocalTime.MIN);
+        LocalDateTime endDateTime = LocalDateTime.of(endDate, LocalTime.MAX);
+
+        return Optional.ofNullable(queryFactory.select(history.cost.sum())
+                .from(history)
+                .where(history.memberId.eq(memberId)
+                        .and(history.cost.gt(0))
+                        .and(history.usedAt.between(startDateTime, endDateTime)))
                 .fetchOne());
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
https://github.com/project-porko/porko-service/issues/53 기간별 수입/지출 계산 쿼리 작성

## 📝작업 내용
특정 날짜 or 특정 기간의 수입/지출 값을 QueryDSL을 사용해 계산했습니다.

[QueryDSL을 이용한 쿼리 작성](https://github.com/project-porko/porko-service/commit/c5e2eb63a7d023a9bf3c87ba19034fe1434ff9b9)

---
이후에 캘린더쪽 작업할 때 다시 수정되어야 하지만,
입출금 내역 보기 쪽에서 사용해야 하는 부분이기 때문에 우선 머지하려고 합니다.