### PR TITLE
refactor: Web layer test 수행 속도 및 분리된 테스트 설정 환경 개선을 위한 리팩토링

### DIFF
--- a/porko-common/src/main/resources/properties/logging.yml
+++ b/porko-common/src/main/resources/properties/logging.yml
@@ -1,6 +1,8 @@
 spring.config.activate.on-profile: logging-local
 logging:
   level:
-    io.porko: debug
-    org.springframework.web.servlet: debug
-    org.hibernate.type.descriptor.sql.BasicBinder: trace
+    io.porko: DEBUG
+    org.springframework:
+      web.servlet: DEBUG
+      test.context.cache: DEBUG
+    org.hibernate.type.descriptor.sql.BasicBinder: TRACE

--- a/porko-common/src/test/java/io/porko/config/base/presentation/RequestBuilder.java
+++ b/porko-common/src/test/java/io/porko/config/base/presentation/RequestBuilder.java
@@ -5,7 +5,6 @@ import static org.springframework.http.HttpMethod.DELETE;
 import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.http.HttpMethod.PUT;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
@@ -203,7 +202,6 @@ public class RequestBuilder {
         }
 
         return mockMvc.perform(request)
-            .andDo(print())
             .andExpect(status().is(status.value()));
     }
 }

--- a/porko-service/src/test/java/io/porko/auth/controller/AuthControllerTest.java
+++ b/porko-service/src/test/java/io/porko/auth/controller/AuthControllerTest.java
@@ -6,30 +6,16 @@ import static io.porko.config.security.TestSecurityConfig.testPorkoPrincipal;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
-import io.porko.auth.config.SecurityConfig;
-import io.porko.auth.config.jwt.JwtProperties;
 import io.porko.auth.controller.model.LoginRequest;
 import io.porko.auth.controller.model.LoginResponse;
 import io.porko.auth.exception.AuthException;
-import io.porko.auth.service.AuthService;
+import io.porko.config.base.WebLayerTestBase;
 import io.porko.config.base.presentation.RequestBuilder.Expect;
-import io.porko.config.base.presentation.WebMvcTestBase;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
 
-@WebMvcTest(AuthController.class)
 @DisplayName("Controller:Auth")
-@Import(SecurityConfig.class)
-class AuthControllerTest extends WebMvcTestBase {
-    @MockBean
-    private AuthService authService;
-
-    @MockBean
-    JwtProperties jwtProperties;
-
+class AuthControllerTest extends WebLayerTestBase {
     private static final String LOGIN_URI = "/login";
     private static final LoginRequest loginRequest = new LoginRequest(TEST_PORKO_MEMBER_EMAIL, "password");
 

--- a/porko-service/src/test/java/io/porko/config/base/WebLayerTestBase.java
+++ b/porko-service/src/test/java/io/porko/config/base/WebLayerTestBase.java
@@ -1,0 +1,53 @@
+package io.porko.config.base;
+
+import io.porko.auth.config.jwt.JwtProperties;
+import io.porko.auth.controller.AuthController;
+import io.porko.auth.service.AuthService;
+import io.porko.config.base.presentation.WebMvcTestBase;
+import io.porko.config.cache.CacheConfig;
+import io.porko.config.security.TestSecurityConfig;
+import io.porko.member.controller.MemberController;
+import io.porko.member.facade.ValidateDuplicateFacade;
+import io.porko.member.service.MemberService;
+import io.porko.widget.controller.MemberWidgetController;
+import io.porko.widget.controller.WidgetController;
+import io.porko.widget.service.MemberWidgetService;
+import io.porko.widget.service.WidgetService;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Import;
+
+@WebMvcTest(
+    controllers = {
+        AuthController.class,
+        MemberController.class,
+        MemberWidgetController.class,
+        WidgetController.class,
+        CacheManager.class
+    }
+)
+@Import({TestSecurityConfig.class, CacheConfig.class})
+public abstract class WebLayerTestBase extends WebMvcTestBase {
+    @SpyBean
+    protected JwtProperties jwtProperties;
+
+    @SpyBean
+    protected CacheManager cacheManager;
+
+    @MockBean
+    protected AuthService authService;
+
+    @MockBean
+    protected MemberService memberService;
+
+    @MockBean
+    protected ValidateDuplicateFacade validateDuplicateFacade;
+
+    @MockBean
+    protected WidgetService widgetService;
+
+    @MockBean
+    protected MemberWidgetService memberWidgetService;
+}

--- a/porko-service/src/test/java/io/porko/config/cache/CacheConfigTest.java
+++ b/porko-service/src/test/java/io/porko/config/cache/CacheConfigTest.java
@@ -11,12 +11,9 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.cache.CacheManager;
 import org.springframework.cache.caffeine.CaffeineCache;
 
 @DisplayName("Config:Cache")
-@WebMvcTest(controllers = CacheManager.class)
 class CacheConfigTest extends CacheConfigTestHelper {
     @Test
     @DisplayName("캐시 매니저에 등록된 캐시 목록 확인")

--- a/porko-service/src/test/java/io/porko/config/cache/CacheConfigTestHelper.java
+++ b/porko-service/src/test/java/io/porko/config/cache/CacheConfigTestHelper.java
@@ -2,21 +2,14 @@ package io.porko.config.cache;
 
 import static io.porko.widget.controller.WidgetControllerTestHelper.widgets;
 
-import io.porko.config.base.TestBase;
+import io.porko.config.base.WebLayerTestBase;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.cache.CacheManager;
-import org.springframework.context.annotation.Import;
 
-@Import(CacheConfig.class)
-class CacheConfigTestHelper extends TestBase {
+class CacheConfigTestHelper extends WebLayerTestBase {
     protected final static String cacheName = CacheType.WIDGETS.getName();
     protected final static String testKey = "test::key";
     protected final static String testValue = "test-value";
-
-    @SpyBean
-    protected CacheManager cacheManager;
 
     @BeforeEach
     void setUp() {

--- a/porko-service/src/test/java/io/porko/config/security/TestSecurityConfig.java
+++ b/porko-service/src/test/java/io/porko/config/security/TestSecurityConfig.java
@@ -5,13 +5,10 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 
 import io.porko.auth.config.SecurityConfig;
-import io.porko.auth.config.jwt.JwtProperties;
 import io.porko.auth.controller.model.PorkoPrincipal;
-import io.porko.auth.service.AuthService;
 import io.porko.member.domain.Address;
 import io.porko.member.domain.Gender;
 import io.porko.member.domain.Member;
-import jakarta.annotation.Resource;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
@@ -21,13 +18,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 @Import(SecurityConfig.class)
 public class TestSecurityConfig {
     @MockBean
-    private AuthService authService;
-
-    @MockBean
     private InMemoryUserDetailsManager inMemoryUserDetailsManager;
-
-    @Resource
-    public JwtProperties jwtProperties;
 
     @BeforeTestMethod
     public void setUp() {

--- a/porko-service/src/test/java/io/porko/member/controller/MemberControllerTest.java
+++ b/porko-service/src/test/java/io/porko/member/controller/MemberControllerTest.java
@@ -17,7 +17,6 @@ import static org.springframework.http.HttpHeaders.LOCATION;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 import io.porko.config.fixture.FixtureCommon;
-import io.porko.config.security.TestSecurityConfig;
 import io.porko.member.controller.model.MemberResponse;
 import io.porko.member.controller.model.signup.SignUpRequest;
 import io.porko.member.controller.model.validateduplicate.AvailabilityStatus;
@@ -32,14 +31,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.TestExecutionEvent;
 import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.ResultActions;
 
 @DisplayName("Controller:Member")
-@Import(TestSecurityConfig.class)
 class MemberControllerTest extends MemberControllerTestHelper {
     @Test
     @DisplayName("[중복 검사 가능 항목 조회][GET:200]")

--- a/porko-service/src/test/java/io/porko/member/controller/MemberControllerTestHelper.java
+++ b/porko-service/src/test/java/io/porko/member/controller/MemberControllerTestHelper.java
@@ -1,25 +1,14 @@
 package io.porko.member.controller;
 
+import io.porko.config.base.WebLayerTestBase;
 import io.porko.config.base.presentation.RequestBuilder.Expect;
-import io.porko.config.base.presentation.WebMvcTestBase;
 import io.porko.member.controller.model.signup.AddressDto;
 import io.porko.member.controller.model.signup.SignUpRequest;
 import io.porko.member.controller.model.validateduplicate.ValidateDuplicateType;
-import io.porko.member.facade.ValidateDuplicateFacade;
-import io.porko.member.service.MemberService;
-import org.junit.jupiter.api.DisplayName;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
 @WebMvcTest(MemberController.class)
-@DisplayName("Controller:Member")
-class MemberControllerTestHelper extends WebMvcTestBase {
-    @MockBean
-    protected MemberService memberService;
-
-    @MockBean
-    protected ValidateDuplicateFacade validateDuplicateFacade;
-
+class MemberControllerTestHelper extends WebLayerTestBase {
     private static final String MEMBER_SIGN_UP_URI = "/member/sign-up";
     private static final String MEMBER_SIGN_UP_VALIDATE_DUPLICATE_URL = "/member/validate?type={type}&value={value}";
     private static final String ME_URI = "/member/me";

--- a/porko-service/src/test/java/io/porko/widget/controller/MemberWidgetControllerTest.java
+++ b/porko-service/src/test/java/io/porko/widget/controller/MemberWidgetControllerTest.java
@@ -7,30 +7,18 @@ import static io.porko.widget.fixture.MemberWidgetFixture.valiedReorderWidgetReq
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
-import io.porko.config.base.presentation.WebMvcTestBase;
+import io.porko.config.base.WebLayerTestBase;
 import io.porko.config.fixture.FixtureCommon;
-import io.porko.config.security.TestSecurityConfig;
 import io.porko.widget.controller.model.OrderedMemberWidgetsResponse;
 import io.porko.widget.controller.model.ReorderWidgetRequest;
-import io.porko.widget.service.MemberWidgetService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.TestExecutionEvent;
 import org.springframework.security.test.context.support.WithUserDetails;
-import org.springframework.test.web.servlet.ResultActions;
 
-@WebMvcTest(MemberWidgetController.class)
 @DisplayName("Controller:MemberWidget")
-@Import(TestSecurityConfig.class)
-class MemberWidgetControllerTest extends WebMvcTestBase {
-    @MockBean
-    protected MemberWidgetService memberWidgetService;
-
+class MemberWidgetControllerTest extends WebLayerTestBase {
     @Test
     @WithUserDetails(value = TEST_PORKO_MEMBER_EMAIL, setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @DisplayName("[회원 위젯 순서 변경][PUT:201]")
@@ -40,14 +28,13 @@ class MemberWidgetControllerTest extends WebMvcTestBase {
         willDoNothing().given(memberWidgetService).reorderWidget(TEST_PORKO_ID, given);
 
         // When
-        ResultActions resultActions = put()
+        put()
             .url(MEMBER_WIDGET_BASE_URI)
             .noAuthentication()
             .jsonContent(given)
             .created();
 
         // Then
-        resultActions.andDo(print());
         verify(memberWidgetService).reorderWidget(TEST_PORKO_ID, given);
     }
 
@@ -65,17 +52,17 @@ class MemberWidgetControllerTest extends WebMvcTestBase {
     @WithUserDetails(value = TEST_PORKO_MEMBER_EMAIL, setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @DisplayName("[회원 위젯 순서 조회][GET:200]")
     void getOrderedMemberWidget() throws Exception {
-        OrderedMemberWidgetsResponse given = FixtureCommon.dtoType().giveMeBuilder(OrderedMemberWidgetsResponse.class).sample();
-
         // Given
+        OrderedMemberWidgetsResponse given = FixtureCommon.dtoType()
+            .giveMeBuilder(OrderedMemberWidgetsResponse.class)
+            .sample();
+        
         given(memberWidgetService.loadOrderedMemberWidgets(TEST_PORKO_ID)).willReturn(given);
 
-        // When
+        // When & Then
         get()
-            .url("/member/widget")
+            .url(MEMBER_WIDGET_BASE_URI)
             .noAuthentication()
             .expect().ok();
-
-        // Then
     }
 }

--- a/porko-service/src/test/java/io/porko/widget/controller/WidgetControllerTest.java
+++ b/porko-service/src/test/java/io/porko/widget/controller/WidgetControllerTest.java
@@ -5,9 +5,7 @@ import static org.mockito.BDDMockito.given;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 
-@WebMvcTest(WidgetController.class)
 @DisplayName("Controller:Widget")
 class WidgetControllerTest extends WidgetControllerTestHelper {
     // TODO: TC 기반 API docs 추출을 위해 Mocking된 응답에 Null로 설정된 ID(PK)필드 값 설정

--- a/porko-service/src/test/java/io/porko/widget/controller/WidgetControllerTestHelper.java
+++ b/porko-service/src/test/java/io/porko/widget/controller/WidgetControllerTestHelper.java
@@ -1,20 +1,12 @@
 package io.porko.widget.controller;
 
-import io.porko.config.base.presentation.WebMvcTestBase;
-import io.porko.config.security.TestSecurityConfig;
+import io.porko.config.base.WebLayerTestBase;
 import io.porko.widget.controller.model.WidgetsResponse;
 import io.porko.widget.domain.Widget;
 import io.porko.widget.domain.WidgetCode;
-import io.porko.widget.service.WidgetService;
 import java.util.List;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
 
-@Import(TestSecurityConfig.class)
-public class WidgetControllerTestHelper extends WebMvcTestBase {
-    @MockBean
-    protected WidgetService widgetService;
-
+public class WidgetControllerTestHelper extends WebLayerTestBase {
     public static List<Widget> widgets;
 
     static {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #72 TC 실행 환경 개선(Spring Context 재활용, Controller Mocking Test Config 통합)

## 📝작업 내용
각 Controller Test Class에서 사용하는 각기 다른 MockBean, SpyBean으로 인해 매번 SpringContext가 로드되어 테스트 수행 시간이 오래 걸리는 현상을 개선하고, 웹 계층 Test를 위해 필요한 Spring Security설정, MockMvc를 이용하기 위한 MokcMvc 설정 등의 분리된 설정을 손 쉽게 적용하고 관리 하기 위한 상위 클래스를 정의하여 테스트 작성 환경을 개선하였습니다.

- [WebLayer Test 구동 시 Spring Context 재활용을 위한 상위 클래스 정의](https://github.com/project-porko/porko-service/commit/ca1bdc1a36dad73a4cee2b22d205df3aae9c5f6e)
- [WebLayer Test 관련 Class에 WebLayerTestBase 상속 적용](https://github.com/project-porko/porko-service/commit/e5f2c47dd365cc0f39351ddc3a8b52f7a9e35d36)

---
This closes #72  TC 실행 환경 개선(Spring Context 재활용, Controller Mocking Test Config 통합)