### PR TITLE
build: 도커 빌드를 위한 Dockerfile 작성

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM openjdk:17-jdk-slim AS JAR_BUILDER
+
+WORKDIR /app
+COPY . /app
+ARG JAR_ARTIFACT=porko-service/build/libs/*jar
+
+RUN ./gradlew bootJar
+COPY ${JAR_ARTIFACT} /app
+
+FROM amazoncorretto:17-alpine AS JRE_BUILDER
+
+RUN apk add --no-cache binutils
+RUN jlink \
+      --verbose \
+      --add-modules java.base,java.compiler,java.desktop,java.instrument,java.management,java.naming,java.prefs,java.rmi,java.scripting,java.security.jgss,java.sql,jdk.httpserver,jdk.jfr,jdk.unsupported,jdk.crypto.ec,jdk.crypto.cryptoki \
+      --strip-debug \
+      --no-man-pages \
+      --no-header-files \
+      --compress=2 \
+      --output /jre
+
+FROM alpine:3.20
+
+ENV JAVA_HOME=/jre
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+COPY --from=JRE_BUILDER /jre $JAVA_HOME
+
+ARG APPLICATION_USER=appuser
+RUN adduser --no-create-home -u 1000 -D $APPLICATION_USER
+RUN mkdir /app && chown -R $APPLICATION_USER /app
+USER 1000
+
+ARG JAR_FILE=/app/*.jar
+COPY --chown=1000:1000 --from=JAR_BUILDER ${JAR_FILE} app.jar
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,9 @@
 version: '3.9'
 services:
-  mysql:
+
+  porko-mysql:
+    container_name: porko-mysql-local
     env_file: .env
-    container_name: porko-mysql
     image: mysql:8.0
     command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --lower_case_table_names=1
     ports:
@@ -17,3 +18,16 @@ services:
       - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
       - MYSQL_USER=${MYSQL_USER}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+
+  porko-service:
+    container_name: porko-app-local
+    env_file: .env
+    image: porko-app-local:latest
+    depends_on:
+      - porko-mysql
+    ports:
+      - "8080:8080"
+    environment:
+      - SPRING_DATASOURCE_URL=${DATASOURCE_URL}:${EXPOSE_PORT}/${MYSQL_DATABASE}?useUnicode=yes&characterEncoding=UTF-8&rewriteBatchedStatements=true
+      - SPRING_DATASOURCE_USERNAME=${MYSQL_USER}
+      - SPRING_DATASOURCE_PASSWORD=${MYSQL_PASSWORD}

--- a/porko-service/build.gradle.kts
+++ b/porko-service/build.gradle.kts
@@ -1,3 +1,9 @@
+val bootJar: org.springframework.boot.gradle.tasks.bundling.BootJar by tasks
+val jar: Jar by tasks
+
+bootJar.enabled = true
+jar.enabled = false
+
 val testSourceSet: SourceSetOutput = project(":porko-common").sourceSets["test"].output
 val queryDslVersion = dependencyManagement.importedProperties["querydsl.version"]
 
@@ -31,9 +37,6 @@ dependencies {
     testImplementation(testSourceSet)
 }
 
-tasks.withType<Test> {
-    useJUnitPlatform()
-}
 val qClassGeneratedPath: String = layout.projectDirectory.dir("src/main/generated").asFile.path
 
 sourceSets {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #74 DockerFile 작성 : Dockerizing (경량화)

## 📝작업 내용
Docker Image 생성을 위해 project code를 Docker container 내부로 복사하고, gradle build 결과 생성된 *.jar 파일을 image Docker image로 생성하는 과정에서 소스코드 등 이미지 실행에는 불필요한 요소가 포함되어 이미지용량이 커지는 현상을 개선하기 위해 Multi stage build를 구성

- 초기 전체 프로젝트 소스코드를 컨테이너로 복사 후 빌드하여 생성된 Jar를 기반으로 생성한 Docker image의 크기 : 약 1.2G
-  Build 단계, build 결과 생성된 jar를 복사하는 단계, Jar 실행을 위해 경량화된 JRE를 생성하고 alpine 이미지에 결합하는 단계로 구성된 Multi stage build 결과 생성된 Docker image의 크기 : 약 119MB 

## 미 포함 작업
- 추후 build.gradle에서 project명과 version 정보를 Dockerfile의 ARG로 전달 받아 하드코딩된 요소를 제거

참조 URL
- [Spring Boot 컨테이너 이미지 사이즈 경량화 방법](https://devocean.sk.com/blog/techBoardDetail.do?ID=165369&boardType=techBlog)
- [Dockerfile debugging tip](https://makeoptim.com/en/tool/docker-build-not-output/)
---
This closes #74 DockerFile 작성 : Dockerizing (경량화)