### PR TITLE
feat: API Docs 제공을 위한 Swagger 적용

### DIFF
--- a/porko-service/build.gradle.kts
+++ b/porko-service/build.gradle.kts
@@ -30,6 +30,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-cache")
     implementation("com.github.ben-manes.caffeine:caffeine")
 
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
+
     testRuntimeOnly("com.h2database:h2")
     runtimeOnly("com.mysql:mysql-connector-j")
 

--- a/porko-service/src/main/java/io/porko/auth/config/SecurityConfig.java
+++ b/porko-service/src/main/java/io/porko/auth/config/SecurityConfig.java
@@ -14,6 +14,9 @@ import org.springframework.security.config.annotation.web.configurers.HeadersCon
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @RequiredArgsConstructor
@@ -27,6 +30,7 @@ public class SecurityConfig {
         return http
             .formLogin(AbstractHttpConfigurer::disable)
             .httpBasic(AbstractHttpConfigurer::disable)
+            .cors(httpSecurityCorsConfigurer -> corsConfigurationSource())
             .csrf(AbstractHttpConfigurer::disable)
             .headers(headersConfigurer -> headersConfigurer
                 .frameOptions(FrameOptionsConfig::disable)
@@ -39,6 +43,7 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.POST, "/member/sign-up", "/login").permitAll()
                 .requestMatchers(HttpMethod.GET, "/member/validate", "/member/validate/types").permitAll()
                 .requestMatchers(HttpMethod.GET, "/widget").permitAll()
+                .requestMatchers(HttpMethod.GET, "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                 .anyRequest().authenticated()
             )
             // [TODO:Feature] : 403 권한 없음 예외 처리를 위한 AccessDeniedHandler 구현 및 등록
@@ -50,5 +55,19 @@ public class SecurityConfig {
                 UsernamePasswordAuthenticationFilter.class
             )
             .build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        configuration.addAllowedOrigin("*");
+        configuration.addAllowedHeader("*");
+        configuration.addAllowedMethod("*");
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }

--- a/porko-service/src/main/java/io/porko/config/swagger/SwaggerConfig.java
+++ b/porko-service/src/main/java/io/porko/config/swagger/SwaggerConfig.java
@@ -1,0 +1,30 @@
+package io.porko.config.swagger;
+
+import static io.jsonwebtoken.Header.JWT_TYPE;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        String tokenType = JWT_TYPE;
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(tokenType);
+        Components components = new Components().addSecuritySchemes(tokenType, new SecurityScheme()
+            .name(tokenType)
+            .type(SecurityScheme.Type.HTTP)
+            .scheme("bearer")
+            .bearerFormat(tokenType)
+        );
+
+        return new OpenAPI()
+            .components(new Components())
+            .addSecurityItem(securityRequirement)
+            .components(components);
+    }
+}

--- a/porko-service/src/main/java/io/porko/member/controller/MemberController.java
+++ b/porko-service/src/main/java/io/porko/member/controller/MemberController.java
@@ -25,7 +25,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping(
     value = MEMBER_BASE_URI,
-    consumes = MediaType.APPLICATION_JSON_VALUE,
     produces = MediaType.APPLICATION_JSON_VALUE
 )
 @RestController

--- a/porko-service/src/main/java/io/porko/widget/controller/MemberWidgetController.java
+++ b/porko-service/src/main/java/io/porko/widget/controller/MemberWidgetController.java
@@ -20,7 +20,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping(
     value = MEMBER_WIDGET_BASE_URI,
-    consumes = MediaType.APPLICATION_JSON_VALUE,
     produces = MediaType.APPLICATION_JSON_VALUE
 )
 @RequiredArgsConstructor

--- a/porko-service/src/main/java/io/porko/widget/controller/WidgetController.java
+++ b/porko-service/src/main/java/io/porko/widget/controller/WidgetController.java
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping(
     value = WIDGET_BASE_URI,
-    consumes = MediaType.APPLICATION_JSON_VALUE,
     produces = MediaType.APPLICATION_JSON_VALUE
 )
 @RestController


### PR DESCRIPTION
## #️⃣연관된 이슈

> #83 API Docs 제공을 위한 Swagger 적용


## 📝작업 내용
API docs 제공 및 Test 환경 제공을 위해 Swagger 추가 및 관련 설정을 적용하였습니다.
또한, Swagger를 통한 API 호출 허용을 위해 기존 Controller Layer에 작성된 Content-type을 application/json으로 강제하는 Matcting Rule을 제거하였습니다.


- [x] swagger 의존성 추가
- [x] swagger 구동을 위한 설정 추가
- [x] swagger endpoint 허용을 위한 SecurityConfig 인가 정책 수정
- [x] swagger를 통한 API 호출 허용 처리를 위한 content-type matching rule 제거

서버 구동 후 `http://{domain}/swagger-ui/index.html#` 주소로 접속하시면 Swagger 페이지에 접속하실 수 있습니다.

- 로컬 : http://localhost:8080/swagger-ui/index.html#

---
This closes #83 API Docs 제공을 위한 Swagger 적용