### PR TITLE
refactor: Exception 처리를 위한 오류 메세지 가공 부 중복 제거

### DIFF
--- a/porko-common/src/main/java/io/porko/exception/BusinessException.java
+++ b/porko-common/src/main/java/io/porko/exception/BusinessException.java
@@ -14,4 +14,14 @@ public abstract class BusinessException extends RuntimeException {
         this.code = code;
         this.message = message;
     }
+
+    public BusinessException(HttpStatus status, String code, String message, Object... args) {
+        this.status = status;
+        this.code = code;
+        this.message = formattingErrorMessage(message, args);
+    }
+
+    protected String formattingErrorMessage(String message, Object... objects) {
+        return message.formatted(objects);
+    }
 }

--- a/porko-common/src/main/java/io/porko/exception/BusinessException.java
+++ b/porko-common/src/main/java/io/porko/exception/BusinessException.java
@@ -10,18 +10,20 @@ public abstract class BusinessException extends RuntimeException {
     private final String message;
 
     public BusinessException(HttpStatus status, String code, String message) {
+        super(message);
         this.status = status;
         this.code = code;
         this.message = message;
     }
 
     public BusinessException(HttpStatus status, String code, String message, Object... args) {
+        super(formattingErrorMessage(message, args));
         this.status = status;
         this.code = code;
         this.message = formattingErrorMessage(message, args);
     }
 
-    protected String formattingErrorMessage(String message, Object... objects) {
+    private static String formattingErrorMessage(String message, Object... objects) {
         return message.formatted(objects);
     }
 }

--- a/porko-service/src/main/java/io/porko/auth/exception/AuthErrorCode.java
+++ b/porko-service/src/main/java/io/porko/auth/exception/AuthErrorCode.java
@@ -21,8 +21,4 @@ public enum AuthErrorCode {
         this.status = status;
         this.message = message;
     }
-
-    public String formattingErrorMessage(Object... objects) {
-        return getMessage().formatted(objects);
-    }
 }

--- a/porko-service/src/main/java/io/porko/auth/exception/AuthException.java
+++ b/porko-service/src/main/java/io/porko/auth/exception/AuthException.java
@@ -1,10 +1,11 @@
 package io.porko.auth.exception;
 
 import io.porko.exception.BusinessException;
+import lombok.Getter;
 
+@Getter
 public class AuthException extends BusinessException {
-    private AuthErrorCode errorCode;
-    private String message;
+    private final AuthErrorCode errorCode;
 
     public AuthException(AuthErrorCode errorCode) {
         super(
@@ -12,5 +13,6 @@ public class AuthException extends BusinessException {
             errorCode.name(),
             errorCode.getMessage()
         );
+        this.errorCode = errorCode;
     }
 }

--- a/porko-service/src/main/java/io/porko/budget/exception/BudgetErrorCode.java
+++ b/porko-service/src/main/java/io/porko/budget/exception/BudgetErrorCode.java
@@ -11,8 +11,4 @@ public enum BudgetErrorCode {
 
     private final HttpStatus status;
     private final String message;
-
-    public String formattingErrorMessage(Object... objects) {
-        return getMessage().formatted(objects);
-    }
 }

--- a/porko-service/src/main/java/io/porko/budget/exception/BudgetException.java
+++ b/porko-service/src/main/java/io/porko/budget/exception/BudgetException.java
@@ -1,6 +1,7 @@
 package io.porko.budget.exception;
 
 import io.porko.exception.BusinessException;
+
 public class BudgetException extends BusinessException {
     private BudgetErrorCode errorCode;
     private String message;
@@ -9,7 +10,8 @@ public class BudgetException extends BusinessException {
         super(
             errorCode.getStatus(),
             errorCode.name(),
-            errorCode.formattingErrorMessage(args)
+            errorCode.getMessage(),
+            args
         );
     }
 }

--- a/porko-service/src/main/java/io/porko/member/exception/MemberErrorCode.java
+++ b/porko-service/src/main/java/io/porko/member/exception/MemberErrorCode.java
@@ -22,8 +22,4 @@ public enum MemberErrorCode {
         this.status = status;
         this.message = message;
     }
-
-    public String formattingErrorMessage(Object... objects) {
-        return getMessage().formatted(objects);
-    }
 }

--- a/porko-service/src/main/java/io/porko/member/exception/MemberException.java
+++ b/porko-service/src/main/java/io/porko/member/exception/MemberException.java
@@ -1,10 +1,11 @@
 package io.porko.member.exception;
 
 import io.porko.exception.BusinessException;
+import lombok.Getter;
 
+@Getter
 public class MemberException extends BusinessException {
-    private MemberErrorCode errorCode;
-    private String message;
+    private final MemberErrorCode errorCode;
 
     public MemberException(MemberErrorCode errorCode, Object... args) {
         super(
@@ -13,5 +14,6 @@ public class MemberException extends BusinessException {
             errorCode.getMessage(),
             args
         );
+        this.errorCode = errorCode;
     }
 }

--- a/porko-service/src/main/java/io/porko/member/exception/MemberException.java
+++ b/porko-service/src/main/java/io/porko/member/exception/MemberException.java
@@ -10,7 +10,8 @@ public class MemberException extends BusinessException {
         super(
             errorCode.getStatus(),
             errorCode.name(),
-            errorCode.formattingErrorMessage(args)
+            errorCode.getMessage(),
+            args
         );
     }
 }

--- a/porko-service/src/main/java/io/porko/widget/controller/model/ReorderWidgetRequest.java
+++ b/porko-service/src/main/java/io/porko/widget/controller/model/ReorderWidgetRequest.java
@@ -43,42 +43,4 @@ public record ReorderWidgetRequest(
     private static boolean hasDuplicateSequence(Set<Integer> sequenceSet) {
         return sequenceSet.size() != ORDERED_WIDGET_COUNT;
     }
-
-//    public OrderedMemberWidgets toEntity(Member member, List<Widget> targetWidgets) {
-//        validateTargetWidgets(targetWidgets);
-//
-//        Map<Long, Widget> targetWidgetMap = targetWidgets.stream()
-//            .collect(Collectors.toMap(Widget::getId, widget -> widget));
-//
-//        return OrderedMemberWidgets.of(elements.stream()
-//            .map(it -> it.toEntity(member, targetWidgetMap))
-//            .collect(Collectors.toList()));
-//    }
-
-//    private void validateTargetWidgets(List<Widget> targetWidgets) {
-//        validateIncludeFixedWidget(targetWidgets);
-//        validateIncludeNotExistWidget(targetWidgets);
-//    }
-
-//    private static void validateIncludeFixedWidget(List<Widget> targetWidgets) {
-//        Optional<Widget> fixedWidget = targetWidgets.stream()
-//            .filter(it -> it.getWidgetCode().isFixed())
-//            .findFirst();
-//
-//        if (fixedWidget.isPresent()) {
-//            throw new WidgetException(INCLUDE_FIXED_WIDGET);
-//        }
-//    }
-
-//    private void validateIncludeNotExistWidget(List<Widget> targetWidgets) {
-//        if (targetWidgets.size() != ORDERED_WIDGET_COUNT) {
-//            throw new WidgetException(INCLUDE_NOT_EXIST_WIDGET);
-//        }
-//    }
-
-//    public List<Long> extractWidgetIds() {
-//        return elements.stream()
-//            .map(ModifyMemberWidgetOrderDto::widgetId)
-//            .toList();
-//    }
 }

--- a/porko-service/src/main/java/io/porko/widget/exception/WidgetException.java
+++ b/porko-service/src/main/java/io/porko/widget/exception/WidgetException.java
@@ -6,7 +6,7 @@ public class WidgetException extends BusinessException {
     private WidgetErrorCode errorCode;
     private String message;
 
-    public WidgetException(WidgetErrorCode errorCode, Object... args) {
+    public WidgetException(WidgetErrorCode errorCode) {
         super(
             errorCode.getStatus(),
             errorCode.name(),
@@ -14,12 +14,12 @@ public class WidgetException extends BusinessException {
         );
     }
 
-//    public WidgetException(WidgetErrorCode errorCode, Object... args) {
-//        super(
-//            errorCode.getStatus(),
-//            errorCode.name(),
-//            errorCode.getMessage(),
-//            args
-//        );
-//    }
+    public WidgetException(WidgetErrorCode errorCode, Object... args) {
+        super(
+            errorCode.getStatus(),
+            errorCode.name(),
+            errorCode.getMessage(),
+            args
+        );
+    }
 }

--- a/porko-service/src/main/java/io/porko/widget/exception/WidgetException.java
+++ b/porko-service/src/main/java/io/porko/widget/exception/WidgetException.java
@@ -1,10 +1,11 @@
 package io.porko.widget.exception;
 
 import io.porko.exception.BusinessException;
+import lombok.Getter;
 
+@Getter
 public class WidgetException extends BusinessException {
-    private WidgetErrorCode errorCode;
-    private String message;
+    private final WidgetErrorCode errorCode;
 
     public WidgetException(WidgetErrorCode errorCode) {
         super(
@@ -12,6 +13,7 @@ public class WidgetException extends BusinessException {
             errorCode.name(),
             errorCode.getMessage()
         );
+        this.errorCode = errorCode;
     }
 
     public WidgetException(WidgetErrorCode errorCode, Object... args) {
@@ -21,5 +23,6 @@ public class WidgetException extends BusinessException {
             errorCode.getMessage(),
             args
         );
+        this.errorCode = errorCode;
     }
 }

--- a/porko-service/src/test/java/io/porko/auth/domain/TokenResolverTest.java
+++ b/porko-service/src/test/java/io/porko/auth/domain/TokenResolverTest.java
@@ -39,7 +39,7 @@ class TokenResolverTest extends TokenTestHelper {
         // When & Then
         assertThatExceptionOfType(AuthException.class)
             .isThrownBy(() -> TokenResolver.resolve(generate, testJwtProperties))
-            .extracting(AuthException::getCode).isEqualTo(AuthErrorCode.INVALID_SIGNATURE.name())
+            .extracting(AuthException::getErrorCode).isEqualTo(AuthErrorCode.INVALID_SIGNATURE)
         ;
     }
 
@@ -53,7 +53,7 @@ class TokenResolverTest extends TokenTestHelper {
         // When & Then
         assertThatExceptionOfType(AuthException.class)
             .isThrownBy(() -> TokenResolver.resolve(token, testJwtProperties))
-            .extracting(AuthException::getCode).isEqualTo(AuthErrorCode.EXPIRED_TOKEN.name())
+            .extracting(AuthException::getErrorCode).isEqualTo(AuthErrorCode.EXPIRED_TOKEN)
         ;
     }
 
@@ -68,7 +68,7 @@ class TokenResolverTest extends TokenTestHelper {
         // When & Then
         assertThatExceptionOfType(AuthException.class)
             .isThrownBy(() -> TokenResolver.resolve(token, testJwtProperties))
-            .extracting(AuthException::getCode).isEqualTo(AuthErrorCode.UNSUPPORTED_AUDIENCE.name())
+            .extracting(AuthException::getErrorCode).isEqualTo(AuthErrorCode.UNSUPPORTED_AUDIENCE)
         ;
     }
 
@@ -79,7 +79,7 @@ class TokenResolverTest extends TokenTestHelper {
         // When & Then
         assertThatExceptionOfType(AuthException.class)
             .isThrownBy(() -> TokenResolver.resolve(given, testJwtProperties))
-            .extracting(AuthException::getCode).isEqualTo(AuthErrorCode.INVALID_TOKEN_FORMAT.name())
+            .extracting(AuthException::getErrorCode).isEqualTo(AuthErrorCode.INVALID_TOKEN_FORMAT)
         ;
     }
 }

--- a/porko-service/src/test/java/io/porko/member/facade/dto/ValidateDuplicateTypeTest.java
+++ b/porko-service/src/test/java/io/porko/member/facade/dto/ValidateDuplicateTypeTest.java
@@ -28,8 +28,8 @@ class ValidateDuplicateTypeTest {
         Arrays.stream(ValidateDuplicateType.values()).forEach(it ->
             assertThatExceptionOfType(MemberException.class)
                 .isThrownBy(() -> it.validateFormat(value))
-                .extracting(MemberException::getCode)
-                .isEqualTo(INVALID_VALIDATE_DUPLICATE_VALUE_FORMAT.name())
+                .extracting(MemberException::getErrorCode)
+                .isEqualTo(INVALID_VALIDATE_DUPLICATE_VALUE_FORMAT)
         );
     }
 
@@ -40,8 +40,8 @@ class ValidateDuplicateTypeTest {
         // When & Then
         assertThatExceptionOfType(MemberException.class)
             .isThrownBy(() -> type.validateFormat(value))
-            .extracting(MemberException::getCode)
-            .isEqualTo(INVALID_VALIDATE_DUPLICATE_VALUE_FORMAT.name())
+            .extracting(MemberException::getErrorCode)
+            .isEqualTo(INVALID_VALIDATE_DUPLICATE_VALUE_FORMAT)
         ;
     }
 

--- a/porko-service/src/test/java/io/porko/member/service/MemberServiceTest.java
+++ b/porko-service/src/test/java/io/porko/member/service/MemberServiceTest.java
@@ -71,9 +71,9 @@ class MemberServiceTest extends ServiceTestBase {
         // When
         assertThatExceptionOfType(MemberException.class)
             .isThrownBy(() -> memberService.createMember(회원_가입_요청_객체))
-            .extracting(MemberException::getCode, MemberException::getMessage)
+            .extracting(MemberException::getErrorCode, MemberException::getMessage)
             .containsExactly(
-                MemberErrorCode.DUPLICATED_EMAIL.name(),
+                MemberErrorCode.DUPLICATED_EMAIL,
                 MemberErrorCode.DUPLICATED_EMAIL.getMessage().formatted(중복된_회원_이메일)
             )
         ;
@@ -92,9 +92,9 @@ class MemberServiceTest extends ServiceTestBase {
         // When
         assertThatExceptionOfType(MemberException.class)
             .isThrownBy(() -> memberService.createMember(회원_가입_요청_객체))
-            .extracting(MemberException::getCode, MemberException::getMessage)
+            .extracting(MemberException::getErrorCode, MemberException::getMessage)
             .containsExactly(
-                MemberErrorCode.DUPLICATED_PHONE_NUMBER.name(),
+                MemberErrorCode.DUPLICATED_PHONE_NUMBER,
                 MemberErrorCode.DUPLICATED_PHONE_NUMBER.getMessage().formatted(중복된_회원_휴대폰_번호)
             )
         ;

--- a/porko-service/src/test/java/io/porko/widget/controller/WidgetControllerTest.java
+++ b/porko-service/src/test/java/io/porko/widget/controller/WidgetControllerTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.Test;
 
 @DisplayName("Controller:Widget")
 class WidgetControllerTest extends WidgetControllerTestHelper {
-    // TODO: TC 기반 API docs 추출을 위해 Mocking된 응답에 Null로 설정된 ID(PK)필드 값 설정
     @Test
     @DisplayName("[모든 위젯 조회][GET:200]")
     void getAllWidgets() throws Exception {

--- a/porko-service/src/test/java/io/porko/widget/controller/model/ModifyMemberWidgetOrderDtoTest.java
+++ b/porko-service/src/test/java/io/porko/widget/controller/model/ModifyMemberWidgetOrderDtoTest.java
@@ -17,8 +17,8 @@ class ModifyMemberWidgetOrderDtoTest {
         // When & Then
         assertThatExceptionOfType(WidgetException.class)
             .isThrownBy(() -> new ModifyMemberWidgetOrderDto(1L, given))
-            .extracting(WidgetException::getCode)
-            .isEqualTo(WidgetErrorCode.INVALID_SEQUENCE_RANGE.name())
+            .extracting(WidgetException::getErrorCode)
+            .isEqualTo(WidgetErrorCode.INVALID_SEQUENCE_RANGE)
         ;
     }
 }

--- a/porko-service/src/test/java/io/porko/widget/controller/model/ReorderWidgetRequestTest.java
+++ b/porko-service/src/test/java/io/porko/widget/controller/model/ReorderWidgetRequestTest.java
@@ -23,8 +23,8 @@ class ReorderWidgetRequestTest extends TestBase {
             // When & Then
             assertThatExceptionOfType(WidgetException.class)
                 .isThrownBy(() -> new ReorderWidgetRequest(givenBuilder.sampleList(1)))
-                .extracting(WidgetException::getCode)
-                .isEqualTo(WidgetErrorCode.INVALID_REQUEST_ORDERED_WIDGET_COUNT.name());
+                .extracting(WidgetException::getErrorCode)
+                .isEqualTo(WidgetErrorCode.INVALID_REQUEST_ORDERED_WIDGET_COUNT);
         }
 
         @Test
@@ -40,8 +40,8 @@ class ReorderWidgetRequestTest extends TestBase {
             // When & Then
             assertThatExceptionOfType(WidgetException.class)
                 .isThrownBy(() -> new ReorderWidgetRequest(given))
-                .extracting(WidgetException::getCode)
-                .isEqualTo(WidgetErrorCode.DUPLICATED_SEQUENCE.name());
+                .extracting(WidgetException::getErrorCode)
+                .isEqualTo(WidgetErrorCode.DUPLICATED_SEQUENCE);
         }
     }
 }

--- a/porko-service/src/test/java/io/porko/widget/domain/OrderedMemberWidgetsTest.java
+++ b/porko-service/src/test/java/io/porko/widget/domain/OrderedMemberWidgetsTest.java
@@ -40,8 +40,8 @@ class OrderedMemberWidgetsTest extends TestBase {
             // When
             assertThatExceptionOfType(WidgetException.class)
                 .isThrownBy(() -> OrderedMemberWidgets.of(testMember, allWidgets, reorderWidgetRequest))
-                .extracting(WidgetException::getCode)
-                .isEqualTo(WidgetErrorCode.INCLUDE_FIXED_WIDGET.name());
+                .extracting(WidgetException::getErrorCode)
+                .isEqualTo(WidgetErrorCode.INCLUDE_FIXED_WIDGET);
         }
 
         @Test
@@ -60,8 +60,8 @@ class OrderedMemberWidgetsTest extends TestBase {
             // When & Then
             assertThatExceptionOfType(WidgetException.class)
                 .isThrownBy(() -> OrderedMemberWidgets.of(testMember, allWidgets, reorderWidgetRequest))
-                .extracting(WidgetException::getCode)
-                .isEqualTo(WidgetErrorCode.INCLUDE_NOT_EXIST_WIDGET.name());
+                .extracting(WidgetException::getErrorCode)
+                .isEqualTo(WidgetErrorCode.INCLUDE_NOT_EXIST_WIDGET);
         }
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #50 BusinessException 리팩토링
각 도메인에서 예외 발생 시, BusinessException을 상속 받은 CustomException에 반복적으로 구현되는 formatted()의 중복 개선과 에러 파라미터가 없는 경우 에러 메세지 처리를 위한 생성자를 추가하였습니다.

추가로 각 도메인에 구현된 CustomException에 불필요한 message 필드를 제거하고, getter를 추가하여 예외 TC에서 BusinessException의 ErrorCode가 아닌 해당하는 CustomException의 ErrorCode를 참조할 수 있도록 수정하였습니다.

## 📝작업 내용
- [x] BusinessException에 에러 파라미터가 없는 생성자 추가
- [x] 각 도메인의 에러 코드를 표현하는 *ErrorCode에 중복으로 구현된 formatted() 제거

---
This closes #50 BusinessException 리팩토링
