### PR TITLE
perf: 테스트 실행 속도 개선

### DIFF
--- a/porko-service/build.gradle.kts
+++ b/porko-service/build.gradle.kts
@@ -41,6 +41,16 @@ dependencies {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+    maxParallelForks = Runtime.getRuntime().availableProcessors().div(2).takeIf { it > 0 } ?: 1
+
+    forkEvery = 100
+
+    reports.html.required = false
+    reports.junitXml.required = false
+}
+
+tasks.withType<JavaCompile> {
+    options.isFork = true
 }
 
 val qClassGeneratedPath: String = layout.projectDirectory.dir("src/main/generated").asFile.path


### PR DESCRIPTION
## #️⃣연관된 이슈

> #89 테스트 실행 속도 개선

## 📝작업 내용
테스트 케이스 실행 속도를 개선하기 위해 아래와 같은 옵션을 적용하였습니다.

- 현재 수행 머신의 CPU 50% 할당 옵션 추가
- 병렬 TC 수행 옵션 추가 및 병렬 수행 TC 개수 지정(100)
- 불필요 TC report html 문서 생성 옵션 off
---
This closes #89 테스트 실행 속도 개선