### PR TITLE
feat: 목표 예산 관리 API 구현

### DIFF
--- a/porko-service/src/main/java/io/porko/budget/controller/BudgetController.java
+++ b/porko-service/src/main/java/io/porko/budget/controller/BudgetController.java
@@ -37,13 +37,13 @@ public class BudgetController {
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/management")
-    ResponseEntity<ManageBudgetResponse> manageBudget (@LoginMember Long id) {
-        return ResponseEntity.ok(budgetService.manageBudget(id));
-    }
-
     @GetMapping("/lastused")
     ResponseEntity<BudgetResponse> getUsedCostInLastMonth(@LoginMember Long id) {
         return ResponseEntity.ok(budgetService.getUsedCostInLastMonth(id));
+    }
+
+    @GetMapping("/management")
+    ResponseEntity<ManageBudgetResponse> manageBudget (@LoginMember Long id) {
+        return ResponseEntity.ok(budgetService.manageBudget(id));
     }
 }

--- a/porko-service/src/main/java/io/porko/budget/controller/BudgetController.java
+++ b/porko-service/src/main/java/io/porko/budget/controller/BudgetController.java
@@ -3,6 +3,7 @@ package io.porko.budget.controller;
 import io.porko.auth.controller.model.LoginMember;
 import io.porko.budget.controller.model.BudgetRequest;
 import io.porko.budget.controller.model.BudgetResponse;
+import io.porko.budget.controller.model.ManageBudgetResponse;
 import io.porko.budget.service.BudgetService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
@@ -34,5 +35,10 @@ public class BudgetController {
     ResponseEntity<Void> setBudget (@RequestBody BudgetRequest budgetRequest, @LoginMember Long id) {
         budgetService.setBudget(budgetRequest, id);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/management")
+    ResponseEntity<ManageBudgetResponse> manageBudget (@LoginMember Long id) {
+        return ResponseEntity.ok(budgetService.manageBudget(id));
     }
 }

--- a/porko-service/src/main/java/io/porko/budget/controller/BudgetController.java
+++ b/porko-service/src/main/java/io/porko/budget/controller/BudgetController.java
@@ -41,4 +41,9 @@ public class BudgetController {
     ResponseEntity<ManageBudgetResponse> manageBudget (@LoginMember Long id) {
         return ResponseEntity.ok(budgetService.manageBudget(id));
     }
+
+    @GetMapping("/lastused")
+    ResponseEntity<BudgetResponse> getUsedCostInLastMonth(@LoginMember Long id) {
+        return ResponseEntity.ok(budgetService.getUsedCostInLastMonth(id));
+    }
 }

--- a/porko-service/src/main/java/io/porko/budget/controller/model/BudgetRequest.java
+++ b/porko-service/src/main/java/io/porko/budget/controller/model/BudgetRequest.java
@@ -1,6 +1,7 @@
 package io.porko.budget.controller.model;
 
 import io.porko.budget.domain.Budget;
+import io.porko.member.domain.Member;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
@@ -12,9 +13,9 @@ public record BudgetRequest(
         @Size(min = 5, max = 9)
         BigDecimal cost
 ) {
-    public Budget toEntity(Long memberId) {
+    public Budget toEntity(Member member) {
         return Budget.of(
-                memberId,
+                member,
                 cost,
                 LocalDate.now().getYear(),
                 LocalDate.now().getMonthValue()

--- a/porko-service/src/main/java/io/porko/budget/controller/model/ManageBudgetResponse.java
+++ b/porko-service/src/main/java/io/porko/budget/controller/model/ManageBudgetResponse.java
@@ -1,0 +1,20 @@
+package io.porko.budget.controller.model;
+
+import java.math.BigDecimal;
+
+public record ManageBudgetResponse(
+        BigDecimal goalCost,
+        BigDecimal dailyCost,
+        Long overSpend,
+        Long zeroSpend
+
+) {
+    public static ManageBudgetResponse of(
+            BigDecimal goalCost,
+            BigDecimal dailyCost,
+            Long overSpend,
+            Long zeroSpend
+    ) {
+        return new ManageBudgetResponse(goalCost, dailyCost, overSpend, zeroSpend);
+    }
+}

--- a/porko-service/src/main/java/io/porko/budget/controller/model/ManageBudgetResponse.java
+++ b/porko-service/src/main/java/io/porko/budget/controller/model/ManageBudgetResponse.java
@@ -5,15 +5,15 @@ import java.math.BigDecimal;
 public record ManageBudgetResponse(
         BigDecimal goalCost,
         BigDecimal dailyCost,
-        Long overSpend,
-        Long zeroSpend
+        long overSpend,
+        long zeroSpend
 
 ) {
     public static ManageBudgetResponse of(
             BigDecimal goalCost,
             BigDecimal dailyCost,
-            Long overSpend,
-            Long zeroSpend
+            long overSpend,
+            long zeroSpend
     ) {
         return new ManageBudgetResponse(goalCost, dailyCost, overSpend, zeroSpend);
     }

--- a/porko-service/src/main/java/io/porko/budget/domain/Budget.java
+++ b/porko-service/src/main/java/io/porko/budget/domain/Budget.java
@@ -1,5 +1,6 @@
 package io.porko.budget.domain;
 
+import io.porko.member.domain.Member;
 import io.porko.utils.ConvertUtils;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Max;
@@ -19,8 +20,9 @@ public class Budget {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
-    private Long memberId;
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     @Column(nullable = false)
     private BigDecimal goalCost;
@@ -32,23 +34,23 @@ public class Budget {
     private Integer goalMonth;
 
     private Budget(
-            Long memberId,
+            Member member,
             BigDecimal goalCost,
             Integer goalYear,
             Integer goalMonth
     ) {
-        this.memberId = memberId;
+        this.member = member;
         this.goalCost = goalCost;
         this.goalYear = goalYear;
         this.goalMonth = goalMonth;
     }
 
     public static Budget of(
-            Long memberId,
+            Member member,
             BigDecimal goalCost,
             Integer goalYear,
             Integer goalMonth
     ) {
-        return new Budget(memberId, goalCost, goalYear, goalMonth);
+        return new Budget(member, goalCost, goalYear, goalMonth);
     }
 }

--- a/porko-service/src/main/java/io/porko/budget/service/BudgetService.java
+++ b/porko-service/src/main/java/io/porko/budget/service/BudgetService.java
@@ -87,4 +87,15 @@ public class BudgetService {
                 )
         );
     }
+
+
+    public BudgetResponse getUsedCostInLastMonth(Long memberId) {
+        return BudgetResponse.of(historyQueryRepo.calcUsedCostInLastMonth(
+                        LocalDate.now().getYear(),
+                        LocalDate.now().getMonthValue(),
+                        memberId)
+                .orElse(BigDecimal.ZERO)
+                .abs()
+                .stripTrailingZeros());
+    }
 }

--- a/porko-service/src/main/java/io/porko/budget/service/BudgetService.java
+++ b/porko-service/src/main/java/io/porko/budget/service/BudgetService.java
@@ -47,6 +47,16 @@ public class BudgetService {
         budgetRepo.save(budget);
     }
 
+    public BudgetResponse getUsedCostInLastMonth(Long memberId) {
+        return BudgetResponse.of(historyQueryRepo.calcUsedCostInLastMonth(
+                        LocalDate.now().getYear(),
+                        LocalDate.now().getMonthValue(),
+                        memberId)
+                .orElse(BigDecimal.ZERO)
+                .abs()
+                .stripTrailingZeros());
+    }
+
     public ManageBudgetResponse manageBudget (Long memberId) {
         LocalDate today = LocalDate.now();
 
@@ -89,13 +99,5 @@ public class BudgetService {
     }
 
 
-    public BudgetResponse getUsedCostInLastMonth(Long memberId) {
-        return BudgetResponse.of(historyQueryRepo.calcUsedCostInLastMonth(
-                        LocalDate.now().getYear(),
-                        LocalDate.now().getMonthValue(),
-                        memberId)
-                .orElse(BigDecimal.ZERO)
-                .abs()
-                .stripTrailingZeros());
-    }
+
 }

--- a/porko-service/src/main/java/io/porko/history/repo/HistoryQueryRepo.java
+++ b/porko-service/src/main/java/io/porko/history/repo/HistoryQueryRepo.java
@@ -18,7 +18,7 @@ public class HistoryQueryRepo {
     public Optional<BigDecimal> calcTotalCost (Integer goalYear, Integer goalMonth, Long memberId) {
         return Optional.ofNullable(queryFactory.select(history.cost.sum())
                 .from(history)
-                .where(history.memberId.eq(memberId)
+                .where(history.member.id.eq(memberId)
                         .and(history.cost.lt(0))
                         .and(history.usedAt.year().eq(goalYear))
                         .and(history.usedAt.month().eq(goalMonth))
@@ -29,7 +29,7 @@ public class HistoryQueryRepo {
     public Long countOverSpend(Integer goalYear, Integer goalMonth, Long memberId, BigDecimal dailyCost) {
         return Long.valueOf(queryFactory.select()
                 .from(history)
-                .where(history.memberId.eq(memberId)
+                .where(history.member.id.eq(memberId)
                         .and(history.cost.lt(0))
                         .and(history.usedAt.year().eq(goalYear))
                         .and(history.usedAt.month().eq(goalMonth))
@@ -38,15 +38,14 @@ public class HistoryQueryRepo {
                 .fetchCount());
     }
 
-    public Long countSpendingDate(Integer goalYear, Integer goalMonth, Long memberId) {
-        return Long.valueOf(queryFactory.select(history.usedAt.date())
+    public long countSpendingDate(Integer goalYear, Integer goalMonth, Long memberId) {
+        return queryFactory.select(history.usedAt.dayOfMonth().count())
                 .from(history)
-                .where(history.memberId.eq(memberId)
+                .where(history.member.id.eq(memberId)
                         .and(history.cost.lt(0))
                         .and(history.usedAt.year().eq(goalYear))
                         .and(history.usedAt.month().eq(goalMonth))
                         .and(history.usedAt.dayOfMonth().lt(LocalDate.now().getDayOfMonth())))
-                .groupBy(history.usedAt.date())
-                .fetchCount());
+                .fetchCount();
     }
 }

--- a/porko-service/src/main/java/io/porko/history/repo/HistoryQueryRepo.java
+++ b/porko-service/src/main/java/io/porko/history/repo/HistoryQueryRepo.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Repository;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.YearMonth;
 import java.util.Optional;
 
 import static io.porko.history.domain.QHistory.history;
@@ -25,5 +24,29 @@ public class HistoryQueryRepo {
                         .and(history.usedAt.month().eq(goalMonth))
                         .and(history.usedAt.dayOfMonth().lt(LocalDate.now().getDayOfMonth())))
                 .fetchOne());
+    }
+
+    public Long countOverSpend(Integer goalYear, Integer goalMonth, Long memberId, BigDecimal dailyCost) {
+        return Long.valueOf(queryFactory.select()
+                .from(history)
+                .where(history.memberId.eq(memberId)
+                        .and(history.cost.lt(0))
+                        .and(history.usedAt.year().eq(goalYear))
+                        .and(history.usedAt.month().eq(goalMonth))
+                        .and(history.usedAt.dayOfMonth().lt(LocalDate.now().getDayOfMonth()))
+                        .and(history.cost.gt(dailyCost)))
+                .fetchCount());
+    }
+
+    public Long countSpendingDate(Integer goalYear, Integer goalMonth, Long memberId) {
+        return Long.valueOf(queryFactory.select(history.usedAt.date())
+                .from(history)
+                .where(history.memberId.eq(memberId)
+                        .and(history.cost.lt(0))
+                        .and(history.usedAt.year().eq(goalYear))
+                        .and(history.usedAt.month().eq(goalMonth))
+                        .and(history.usedAt.dayOfMonth().lt(LocalDate.now().getDayOfMonth())))
+                .groupBy(history.usedAt.date())
+                .fetchCount());
     }
 }

--- a/porko-service/src/main/java/io/porko/history/repo/HistoryQueryRepo.java
+++ b/porko-service/src/main/java/io/porko/history/repo/HistoryQueryRepo.java
@@ -48,4 +48,21 @@ public class HistoryQueryRepo {
                         .and(history.usedAt.dayOfMonth().lt(LocalDate.now().getDayOfMonth())))
                 .fetchCount();
     }
+
+    public Optional<BigDecimal> calcUsedCostInLastMonth (Integer currentYear, Integer currentMonth, Long memberId) {
+        if (currentMonth == 1) {
+            currentYear -= 1;
+            currentMonth = 12;
+        } else {
+            currentMonth -= 1;
+        }
+
+        return Optional.ofNullable(queryFactory.select(history.cost.sum())
+                .from(history)
+                .where(history.member.id.eq(memberId)
+                        .and(history.cost.lt(0))
+                        .and(history.usedAt.year().eq(currentYear))
+                        .and(history.usedAt.month().eq(currentMonth)))
+                .fetchOne());
+    }
 }

--- a/porko-service/src/main/java/io/porko/history/repo/HistoryQueryRepo.java
+++ b/porko-service/src/main/java/io/porko/history/repo/HistoryQueryRepo.java
@@ -26,6 +26,23 @@ public class HistoryQueryRepo {
                 .fetchOne());
     }
 
+    public Optional<BigDecimal> calcUsedCostInLastMonth (Integer currentYear, Integer currentMonth, Long memberId) {
+        if (currentMonth == 1) {
+            currentYear -= 1;
+            currentMonth = 12;
+        } else {
+            currentMonth -= 1;
+        }
+
+        return Optional.ofNullable(queryFactory.select(history.cost.sum())
+                .from(history)
+                .where(history.member.id.eq(memberId)
+                        .and(history.cost.lt(0))
+                        .and(history.usedAt.year().eq(currentYear))
+                        .and(history.usedAt.month().eq(currentMonth)))
+                .fetchOne());
+    }
+
     public Long countOverSpend(Integer goalYear, Integer goalMonth, Long memberId, BigDecimal dailyCost) {
         return Long.valueOf(queryFactory.select()
                 .from(history)
@@ -47,22 +64,5 @@ public class HistoryQueryRepo {
                         .and(history.usedAt.month().eq(goalMonth))
                         .and(history.usedAt.dayOfMonth().lt(LocalDate.now().getDayOfMonth())))
                 .fetchCount();
-    }
-
-    public Optional<BigDecimal> calcUsedCostInLastMonth (Integer currentYear, Integer currentMonth, Long memberId) {
-        if (currentMonth == 1) {
-            currentYear -= 1;
-            currentMonth = 12;
-        } else {
-            currentMonth -= 1;
-        }
-
-        return Optional.ofNullable(queryFactory.select(history.cost.sum())
-                .from(history)
-                .where(history.member.id.eq(memberId)
-                        .and(history.cost.lt(0))
-                        .and(history.usedAt.year().eq(currentYear))
-                        .and(history.usedAt.month().eq(currentMonth)))
-                .fetchOne());
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
https://github.com/project-porko/porko-service/issues/49 목표 예산 관리 API 구현

## 📝작업 내용
[목표 예산 설정 API 구현](https://github.com/project-porko/porko-service/commit/e1a4c7a72955208183a07fc04b75b47aa1cceed3)
- 남은 예산 조회
- 일 평균 사용 가능 금액 계산
- 지출 금액이 하루 예산을 초과한 일 수 조회
- [무지출 일 수 계산](https://github.com/project-porko/porko-service/commit/7a210f7e28547629b4c622464bc6f73732b202c0)