### PR TITLE
feat: 목표 예산 관리 API 구현

### DIFF
--- a/porko-service/src/main/java/io/porko/budget/controller/BudgetController.java
+++ b/porko-service/src/main/java/io/porko/budget/controller/BudgetController.java
@@ -3,6 +3,7 @@ package io.porko.budget.controller;
 import io.porko.auth.controller.model.LoginMember;
 import io.porko.budget.controller.model.BudgetRequest;
 import io.porko.budget.controller.model.BudgetResponse;
+import io.porko.budget.controller.model.ManageBudgetResponse;
 import io.porko.budget.service.BudgetService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
@@ -39,5 +40,10 @@ public class BudgetController {
     @GetMapping("/lastused")
     ResponseEntity<BudgetResponse> getUsedCostInLastMonth(@LoginMember Long id) {
         return ResponseEntity.ok(budgetService.getUsedCostInLastMonth(id));
+    }
+
+    @GetMapping("/management")
+    ResponseEntity<ManageBudgetResponse> manageBudget (@LoginMember Long id) {
+        return ResponseEntity.ok(budgetService.manageBudget(id));
     }
 }

--- a/porko-service/src/main/java/io/porko/budget/controller/model/BudgetRequest.java
+++ b/porko-service/src/main/java/io/porko/budget/controller/model/BudgetRequest.java
@@ -1,6 +1,7 @@
 package io.porko.budget.controller.model;
 
 import io.porko.budget.domain.Budget;
+import io.porko.member.domain.Member;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
@@ -12,9 +13,9 @@ public record BudgetRequest(
         @Size(min = 5, max = 9)
         BigDecimal cost
 ) {
-    public Budget toEntity(Long memberId) {
+    public Budget toEntity(Member member) {
         return Budget.of(
-                memberId,
+                member,
                 cost,
                 LocalDate.now().getYear(),
                 LocalDate.now().getMonthValue()

--- a/porko-service/src/main/java/io/porko/budget/controller/model/ManageBudgetResponse.java
+++ b/porko-service/src/main/java/io/porko/budget/controller/model/ManageBudgetResponse.java
@@ -1,0 +1,20 @@
+package io.porko.budget.controller.model;
+
+import java.math.BigDecimal;
+
+public record ManageBudgetResponse(
+        BigDecimal goalCost,
+        BigDecimal dailyCost,
+        long overSpend,
+        long zeroSpend
+
+) {
+    public static ManageBudgetResponse of(
+            BigDecimal goalCost,
+            BigDecimal dailyCost,
+            long overSpend,
+            long zeroSpend
+    ) {
+        return new ManageBudgetResponse(goalCost, dailyCost, overSpend, zeroSpend);
+    }
+}

--- a/porko-service/src/main/java/io/porko/budget/domain/Budget.java
+++ b/porko-service/src/main/java/io/porko/budget/domain/Budget.java
@@ -1,5 +1,6 @@
 package io.porko.budget.domain;
 
+import io.porko.member.domain.Member;
 import io.porko.utils.ConvertUtils;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Max;
@@ -19,8 +20,9 @@ public class Budget {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
-    private Long memberId;
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     @Column(nullable = false)
     private BigDecimal goalCost;
@@ -32,23 +34,23 @@ public class Budget {
     private Integer goalMonth;
 
     private Budget(
-            Long memberId,
+            Member member,
             BigDecimal goalCost,
             Integer goalYear,
             Integer goalMonth
     ) {
-        this.memberId = memberId;
+        this.member = member;
         this.goalCost = goalCost;
         this.goalYear = goalYear;
         this.goalMonth = goalMonth;
     }
 
     public static Budget of(
-            Long memberId,
+            Member member,
             BigDecimal goalCost,
             Integer goalYear,
             Integer goalMonth
     ) {
-        return new Budget(memberId, goalCost, goalYear, goalMonth);
+        return new Budget(member, goalCost, goalYear, goalMonth);
     }
 }

--- a/porko-service/src/main/java/io/porko/history/repo/HistoryQueryRepo.java
+++ b/porko-service/src/main/java/io/porko/history/repo/HistoryQueryRepo.java
@@ -17,7 +17,7 @@ import static io.porko.history.domain.QHistory.history;
 public class HistoryQueryRepo {
     private final JPQLQueryFactory queryFactory;
 
-    public Optional<BigDecimal> calcTotalCost (Integer goalYear, Integer goalMonth, Long memberId) {
+    public Optional<BigDecimal> calcTotalCost(Integer goalYear, Integer goalMonth, Long memberId) {
         return Optional.ofNullable(queryFactory.select(history.cost.sum())
                 .from(history)
                 .where(history.member.id.eq(memberId)
@@ -28,7 +28,30 @@ public class HistoryQueryRepo {
                 .fetchOne());
     }
 
-    public Optional<BigDecimal> calcUsedCostInLastMonth (Integer currentYear, Integer currentMonth, Long memberId) {
+    public Long countOverSpend(Integer goalYear, Integer goalMonth, Long memberId, BigDecimal dailyCost) {
+        return Long.valueOf(queryFactory.select()
+                .from(history)
+                .where(history.member.id.eq(memberId)
+                        .and(history.cost.lt(0))
+                        .and(history.usedAt.year().eq(goalYear))
+                        .and(history.usedAt.month().eq(goalMonth))
+                        .and(history.usedAt.dayOfMonth().lt(LocalDate.now().getDayOfMonth()))
+                        .and(history.cost.gt(dailyCost)))
+                .fetchCount());
+    }
+
+    public long countSpendingDate(Integer goalYear, Integer goalMonth, Long memberId) {
+        return queryFactory.select(history.usedAt.dayOfMonth().count())
+                .from(history)
+                .where(history.member.id.eq(memberId)
+                        .and(history.cost.lt(0))
+                        .and(history.usedAt.year().eq(goalYear))
+                        .and(history.usedAt.month().eq(goalMonth))
+                        .and(history.usedAt.dayOfMonth().lt(LocalDate.now().getDayOfMonth())))
+                .fetchCount();
+    }
+
+    public Optional<BigDecimal> calcUsedCostInLastMonth(Integer currentYear, Integer currentMonth, Long memberId) {
         if (currentMonth == 1) {
             currentYear -= 1;
             currentMonth = 12;
@@ -45,7 +68,7 @@ public class HistoryQueryRepo {
                 .fetchOne());
     }
 
-    public Optional<BigDecimal> calcDailyUsedCost (LocalDate date, Long memberId) {
+    public Optional<BigDecimal> calcDailyUsedCost(LocalDate date, Long memberId) {
         return Optional.ofNullable(queryFactory.select(history.cost.sum())
                 .from(history)
                 .where(history.member.id.eq(memberId)
@@ -56,7 +79,7 @@ public class HistoryQueryRepo {
                 .fetchOne());
     }
 
-    public Optional<BigDecimal> calcDailyEarnedCost (LocalDate date, Long memberId) {
+    public Optional<BigDecimal> calcDailyEarnedCost(LocalDate date, Long memberId) {
         return Optional.ofNullable(queryFactory.select(history.cost.sum())
                 .from(history)
                 .where(history.member.id.eq(memberId)
@@ -67,7 +90,7 @@ public class HistoryQueryRepo {
                 .fetchOne());
     }
 
-    public Optional<BigDecimal> calcUsedCostForPeriod (LocalDate startDate, LocalDate endDate, Long memberId) {
+    public Optional<BigDecimal> calcUsedCostForPeriod(LocalDate startDate, LocalDate endDate, Long memberId) {
         LocalDateTime startDateTime = LocalDateTime.of(startDate, LocalTime.MIN);
         LocalDateTime endDateTime = LocalDateTime.of(endDate, LocalTime.MAX);
 
@@ -79,7 +102,7 @@ public class HistoryQueryRepo {
                 .fetchOne());
     }
 
-    public Optional<BigDecimal> calcEarnedCostForPeriod (LocalDate startDate, LocalDate endDate, Long memberId) {
+    public Optional<BigDecimal> calcEarnedCostForPeriod(LocalDate startDate, LocalDate endDate, Long memberId) {
         LocalDateTime startDateTime = LocalDateTime.of(startDate, LocalTime.MIN);
         LocalDateTime endDateTime = LocalDateTime.of(endDate, LocalTime.MAX);
 


### PR DESCRIPTION
## #️⃣연관된 이슈
https://github.com/project-porko/porko-service/issues/49 목표 예산 관리 API 구현

## 📝작업 내용
[목표 예산 설정 API 구현](https://github.com/project-porko/porko-service/commit/d5b0f643fdbf999e517b87b7efe7d84b8e0a37d2)

남은 예산 조회
일 평균 사용 가능 금액 계산
지출 금액이 하루 예산을 초과한 일 수 조회
무지출 일 수 계산