### PR TITLE
feat: 회원 프로필 이미지 저장을 위한 필드 추가

### DIFF
--- a/porko-service/src/main/java/io/porko/member/controller/MemberController.java
+++ b/porko-service/src/main/java/io/porko/member/controller/MemberController.java
@@ -62,7 +62,6 @@ public class MemberController {
 
     @GetMapping("me")
     ResponseEntity<MemberResponse> me(@LoginMember Long loginMemberId) {
-        MemberResponse memberResponse = memberService.loadMemberById(loginMemberId);
-        return ResponseEntity.ok(memberResponse);
+        return ResponseEntity.ok(memberService.loadMemberById(loginMemberId));
     }
 }

--- a/porko-service/src/main/java/io/porko/member/controller/model/MemberResponse.java
+++ b/porko-service/src/main/java/io/porko/member/controller/model/MemberResponse.java
@@ -8,6 +8,7 @@ public record MemberResponse(
     Long id,
     String name,
     String email,
+    String profileImageUrl,
     LocalDateTime registeredAt
 ) {
     @QueryProjection
@@ -19,6 +20,7 @@ public record MemberResponse(
             member.getId(),
             member.getName(),
             member.getEmail(),
+            member.getProfileImageUrl(),
             member.getCreatedAt()
         );
     }

--- a/porko-service/src/main/java/io/porko/member/controller/model/signup/SignUpRequest.java
+++ b/porko-service/src/main/java/io/porko/member/controller/model/signup/SignUpRequest.java
@@ -28,7 +28,10 @@ public record SignUpRequest(
     AddressDto address,
 
     @NotNull
-    Gender gender
+    Gender gender,
+
+    @NotBlank
+    String profileImageUrl
 ) {
     public Member toEntity(String encodedPassword) {
         return Member.of(
@@ -37,7 +40,8 @@ public record SignUpRequest(
             name,
             phoneNumber,
             address.toEntity(),
-            gender
+            gender,
+            profileImageUrl
         );
     }
 }

--- a/porko-service/src/main/java/io/porko/member/domain/Member.java
+++ b/porko-service/src/main/java/io/porko/member/domain/Member.java
@@ -45,13 +45,17 @@ public class Member extends TimeMetaFields {
     @Enumerated(EnumType.STRING)
     private Gender gender;
 
+    @Column(nullable = false)
+    private String profileImageUrl;
+
     private Member(
         String email,
         String password,
         String name,
         String phoneNumber,
         Address address,
-        Gender gender
+        Gender gender,
+        String profileImageUrl
     ) {
         this.email = email;
         this.password = password;
@@ -59,6 +63,7 @@ public class Member extends TimeMetaFields {
         this.phoneNumber = phoneNumber;
         this.address = address;
         this.gender = gender;
+        this.profileImageUrl = profileImageUrl;
     }
 
     public static Member of(
@@ -67,8 +72,9 @@ public class Member extends TimeMetaFields {
         String name,
         String phoneNumber,
         Address address,
-        Gender gender
+        Gender gender,
+        String profileImageUrl
     ) {
-        return new Member(email, password, name, phoneNumber, address, gender);
+        return new Member(email, password, name, phoneNumber, address, gender, profileImageUrl);
     }
 }

--- a/porko-service/src/main/java/io/porko/member/repo/MemberQueryRepo.java
+++ b/porko-service/src/main/java/io/porko/member/repo/MemberQueryRepo.java
@@ -20,6 +20,7 @@ public class MemberQueryRepo {
                     member.id,
                     member.name,
                     member.email,
+                    member.profileImageUrl,
                     member.createdAt
                 ))
             .from(member)

--- a/porko-service/src/main/resources/data.sql
+++ b/porko-service/src/main/resources/data.sql
@@ -1,6 +1,6 @@
-insert into member(detail, road_name, created_at, email, gender, name, password, phone_number, updated_at)
+insert into member(detail, road_name, created_at, email, gender, name, password, phone_number, updated_at, profile_image_url)
 values ('반포동', '서울시 서초구', '2024-05-21T03:29:30.044', 'project.log.062@gmail.com', 'MALE', '최용석',
-        '{bcrypt}$2a$10$8VSoF7WnqGiFDp0XPA93IuKtMLR17Tte6ROVBS8ORVX8nQnJjbJYS', '01011112222', NULL);
+        '{bcrypt}$2a$10$8VSoF7WnqGiFDp0XPA93IuKtMLR17Tte6ROVBS8ORVX8nQnJjbJYS', '01011112222', null, 'https://avatars.githubusercontent.com/u/169456863?s=200&v=4');
 
 ---
 -- widget

--- a/porko-service/src/test/java/io/porko/config/security/TestSecurityConfig.java
+++ b/porko-service/src/test/java/io/porko/config/security/TestSecurityConfig.java
@@ -37,6 +37,7 @@ public class TestSecurityConfig {
         "tester",
         "01011112222",
         Address.of("서울시 서초구", "반포"),
-        Gender.MALE
+        Gender.MALE,
+        "https://avatars.githubusercontent.com/u/169456863?s=200&v=4"
     );
 }

--- a/porko-service/src/test/java/io/porko/member/controller/MemberControllerTestHelper.java
+++ b/porko-service/src/test/java/io/porko/member/controller/MemberControllerTestHelper.java
@@ -18,7 +18,8 @@ class MemberControllerTestHelper extends WebLayerTestBase {
         "",
         "",
         new AddressDto("", ""),
-        null
+        null,
+        "https://avatars.githubusercontent.com/u/169456863?s=200&v=4"
     );
 
     protected Expect 회원_가입_요청(SignUpRequest 회원_가입_요청_정보) {

--- a/porko-service/src/test/java/io/porko/member/repo/MemberRepoTest.java
+++ b/porko-service/src/test/java/io/porko/member/repo/MemberRepoTest.java
@@ -28,7 +28,8 @@ class MemberRepoTest extends JpaTestBase {
             "name",
             "01012345678",
             Address.of("roadName", "detail"),
-            Gender.MALE
+            Gender.MALE,
+            "https://avatars.githubusercontent.com/u/169456863?s=200&v=4"
         );
 
         // When


### PR DESCRIPTION
## #️⃣연관된 이슈

> #125  회원 프로필 이미지 저장을 위한 필드 추가

## 📝작업 내용
기획에 변경에 따라 사용자 프로필 이미지를 저장할 수 있는 필드를 추가 하고, 회원 조회 시 프로필 이미지를 조회할 수 있도록 응답 필드를 수정하였습니다.

---
This closes #125  회원 프로필 이미지 저장을 위한 필드 추가