### PR TITLE
feat: 로그인 응답 필드에 회원 프로필 이미지 주소 추가

### DIFF
--- a/porko-service/src/main/java/io/porko/auth/controller/AuthController.java
+++ b/porko-service/src/main/java/io/porko/auth/controller/AuthController.java
@@ -23,7 +23,6 @@ public class AuthController {
 
     @PostMapping("login")
     ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest loginRequest) {
-        LoginResponse loginResponse = authService.authenticate(loginRequest);
-        return ResponseEntity.ok(loginResponse);
+        return ResponseEntity.ok(authService.authenticate(loginRequest));
     }
 }

--- a/porko-service/src/main/java/io/porko/auth/controller/model/LoginResponse.java
+++ b/porko-service/src/main/java/io/porko/auth/controller/model/LoginResponse.java
@@ -1,14 +1,24 @@
 package io.porko.auth.controller.model;
 
+import io.porko.member.domain.Member;
 import java.time.LocalDateTime;
 
 public record LoginResponse(
     Long id,
+    String name,
     String email,
     String accessToken,
+    String profileImageUrl,
     LocalDateTime loggedInAt
 ) {
-    public static LoginResponse of(PorkoPrincipal porkoPrincipal, String accessToken) {
-        return new LoginResponse(porkoPrincipal.getId(), porkoPrincipal.getUsername(), accessToken, LocalDateTime.now());
+    public static LoginResponse of(Member member, String accessToken) {
+        return new LoginResponse(
+            member.getId(),
+            member.getName(),
+            member.getEmail(),
+            accessToken,
+            member.getProfileImageUrl(),
+            LocalDateTime.now()
+        );
     }
 }

--- a/porko-service/src/main/java/io/porko/auth/service/AuthService.java
+++ b/porko-service/src/main/java/io/porko/auth/service/AuthService.java
@@ -22,16 +22,15 @@ public class AuthService {
     private final TokenService tokenService;
 
     public LoginResponse authenticate(LoginRequest loginRequest) {
-        PorkoPrincipal porkoPrincipal = verifyMember(loginRequest);
+        Member member = loadUserByUsername(loginRequest.email());
+        PorkoPrincipal porkoPrincipal = verifyMember(loginRequest, member);
         String accessToken = tokenService.issueAccessToken(porkoPrincipal);
 
-        return LoginResponse.of(porkoPrincipal, accessToken);
+        return LoginResponse.of(member, accessToken);
     }
 
-    private PorkoPrincipal verifyMember(LoginRequest loginRequest) {
-        Member member = loadUserByUsername(loginRequest.email());
+    private PorkoPrincipal verifyMember(LoginRequest loginRequest, Member member) {
         checkPasswordIsMatched(loginRequest.password(), member.getPassword());
-
         return PorkoPrincipal.of(member.getId(), member.getEmail());
     }
 

--- a/porko-service/src/main/resources/data.sql
+++ b/porko-service/src/main/resources/data.sql
@@ -1,6 +1,6 @@
 insert into member(detail, road_name, created_at, email, gender, name, password, phone_number, updated_at, profile_image_url)
 values ('반포동', '서울시 서초구', '2024-05-21T03:29:30.044', 'project.log.062@gmail.com', 'MALE', '최용석',
-        '{bcrypt}$2a$10$8VSoF7WnqGiFDp0XPA93IuKtMLR17Tte6ROVBS8ORVX8nQnJjbJYS', '01011112222', null, 'https://avatars.githubusercontent.com/u/169456863?s=200&v=4');
+        '{bcrypt}$2a$10$8VSoF7WnqGiFDp0XPA93IuKtMLR17Tte6ROVBS8ORVX8nQnJjbJYS', '01011112222', null, '/images/default-profile/profile_2.jpg');
 
 ---
 -- widget

--- a/porko-service/src/test/java/io/porko/auth/controller/AuthControllerTest.java
+++ b/porko-service/src/test/java/io/porko/auth/controller/AuthControllerTest.java
@@ -2,6 +2,7 @@ package io.porko.auth.controller;
 
 import static io.porko.auth.exception.AuthErrorCode.BAD_CREDENTIALS;
 import static io.porko.config.security.TestSecurityConfig.TEST_MEMBER_EMAIL;
+import static io.porko.config.security.TestSecurityConfig.testMember;
 import static io.porko.config.security.TestSecurityConfig.testPrincipal;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -25,7 +26,7 @@ class AuthControllerTest extends WebLayerTestBase {
     void login() throws Exception {
         // Given
         given(authService.authenticate(loginRequest))
-            .willReturn(LoginResponse.of(testPrincipal, "access token"));
+            .willReturn(LoginResponse.of(testMember, "access token"));
 
         // When & Then
         로그인_요청().ok();


### PR DESCRIPTION
## #️⃣연관된 이슈

> #125  로그인 응답 필드에 회원 프로필 이미지 주소 추가

## 📝작업 내용
FE 요청에 따라 사용자 로그인 응답에 프로필 이미지 필드를 추가하고, 테스트 유저에 샘플 데이터를 추가하였습니다.

---
This closes #125  회원 프로필 이미지 저장을 위한 필드 추가