### PR TITLE
feat: 목표 예산에 따른 캘린더 소비 날씨 처리

### DIFF
--- a/porko-service/src/main/java/io/porko/budget/service/BudgetService.java
+++ b/porko-service/src/main/java/io/porko/budget/service/BudgetService.java
@@ -113,6 +113,6 @@ public class BudgetService {
                         RoundingMode.DOWN
                 )
                 .stripTrailingZeros()
-        ).orElse(BigDecimal.ZERO);
+        ).orElse(null);
     }
 }

--- a/porko-service/src/main/java/io/porko/consumption/domain/Weather.java
+++ b/porko-service/src/main/java/io/porko/consumption/domain/Weather.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.Optional;
 
 @AllArgsConstructor
 @RequiredArgsConstructor
@@ -63,9 +64,11 @@ public enum Weather {
     }
 
     public static Weather getWeatherByDailyUsed(BigDecimal dailyUsed) {
-        return Arrays.stream(values())
-                .filter(it -> it.isMatched(dailyUsed))
-                .findFirst()
-                .orElse(THUNDER);
+        return Optional.ofNullable(dailyUsed)
+                .map(value -> Arrays.stream(values())
+                        .filter(it -> it.isMatched(value))
+                        .findFirst()
+                        .orElse(THUNDER))
+                .orElse(null);
     }
 }

--- a/porko-service/src/main/java/io/porko/consumption/domain/Weather.java
+++ b/porko-service/src/main/java/io/porko/consumption/domain/Weather.java
@@ -44,7 +44,7 @@ public enum Weather {
     public final String weatherName;
     final int startRange;
     int endRange;
-    public final int weatherImageNo;
+    public final Integer weatherImageNo;
 
     abstract boolean isMatched(BigDecimal cost);
 
@@ -64,11 +64,9 @@ public enum Weather {
     }
 
     public static Weather getWeatherByDailyUsed(BigDecimal dailyUsed) {
-        return Optional.ofNullable(dailyUsed)
-                .map(value -> Arrays.stream(values())
-                        .filter(it -> it.isMatched(value))
-                        .findFirst()
-                        .orElse(THUNDER))
-                .orElse(null);
+        return Arrays.stream(values())
+                .filter(it -> it.isMatched(dailyUsed))
+                .findFirst()
+                .orElse(THUNDER);
     }
 }

--- a/porko-service/src/main/java/io/porko/history/controller/model/CalendarResponse.java
+++ b/porko-service/src/main/java/io/porko/history/controller/model/CalendarResponse.java
@@ -7,12 +7,12 @@ public record CalendarResponse(
         String date,
         BigDecimal usedCost,
         BigDecimal earnedCost,
-        int weatherImageNo) {
+        Integer weatherImageNo) {
     public static CalendarResponse of(
             LocalDate localDate,
             BigDecimal usedCost,
             BigDecimal earnedCost,
-            int weatherImageNo) {
+            Integer weatherImageNo) {
         return new CalendarResponse(localDate.toString(), usedCost, earnedCost, weatherImageNo);
     }
 }

--- a/porko-service/src/main/java/io/porko/history/service/HistoryService.java
+++ b/porko-service/src/main/java/io/porko/history/service/HistoryService.java
@@ -98,14 +98,15 @@ public class HistoryService {
 
             BigDecimal dailyUsedCost = calcDailyUsedCost(date, memberId);
             BigDecimal dailyEarnedCost = calcDailyEarnedCost(date, memberId);
-            BigDecimal dailyUsedRate = calcDailyUsedRate(date, memberId, dailyUsedCost);
 
             calendarResponseList.add(
                     CalendarResponse.of(
                             date,
                             dailyUsedCost,
                             dailyEarnedCost,
-                            dailyUsedRate != null ? Weather.getWeatherByDailyUsed(dailyUsedRate).weatherImageNo : null
+                            Optional.ofNullable(calcDailyUsedRate(date, memberId, dailyUsedCost))
+                                    .map(dailyUsedRate -> Weather.getWeatherByDailyUsed(dailyUsedRate).weatherImageNo)
+                                    .orElse(null)
                     )
             );
         }

--- a/porko-service/src/main/java/io/porko/history/service/HistoryService.java
+++ b/porko-service/src/main/java/io/porko/history/service/HistoryService.java
@@ -133,7 +133,7 @@ public class HistoryService {
     private BigDecimal calcDailyUsedRate(LocalDate date, Long memberId, BigDecimal dailyUsedCost) {
         BigDecimal dailyBudget = budgetService.calcDailyBudget(date, memberId);
         if (dailyBudget.equals(BigDecimal.ZERO)) {
-            return BigDecimal.ZERO;
+            return dailyBudget;
         } else {
             return dailyUsedCost.divide(dailyBudget, 2, RoundingMode.HALF_UP)
                     .abs()

--- a/porko-service/src/main/java/io/porko/history/service/HistoryService.java
+++ b/porko-service/src/main/java/io/porko/history/service/HistoryService.java
@@ -98,14 +98,16 @@ public class HistoryService {
 
             BigDecimal dailyUsedCost = calcDailyUsedCost(date, memberId);
             BigDecimal dailyEarnedCost = calcDailyEarnedCost(date, memberId);
-            BigDecimal dailyUsedRate = Optional.ofNullable(calcDailyUsedRate(date, memberId, dailyUsedCost))
-                    .orElse(null);
+            BigDecimal dailyUsedRate = calcDailyUsedRate(date, memberId, dailyUsedCost);
 
-            calendarResponseList.add(CalendarResponse.of(
-                    date,
-                    dailyUsedCost,
-                    dailyEarnedCost,
-                    Weather.getWeatherByDailyUsed(dailyUsedRate).weatherImageNo));
+            calendarResponseList.add(
+                    CalendarResponse.of(
+                            date,
+                            dailyUsedCost,
+                            dailyEarnedCost,
+                            dailyUsedRate != null ? Weather.getWeatherByDailyUsed(dailyUsedRate).weatherImageNo : null
+                    )
+            );
         }
 
         return calendarResponseList;


### PR DESCRIPTION
## #️⃣연관된 이슈
https://github.com/project-porko/porko-service/issues/144 목표 예산에 따른 소비날씨 처리

📝작업 내용
- [하루 예산이 0원일 경우의 리턴 값 수정](https://github.com/project-porko/porko-service/commit/c4b38466e3a7f217daa957128b30e500a65c5cda)
- [목표 예산이 설정되지 않았을 경우의 리턴값 수정](https://github.com/project-porko/porko-service/commit/5d730a5eacde2e662706616a21190063b265ab66)

