### PR TITLE
feat: 공유 멤버 조회시 멤버 수 조회 기능 추가 구현

### DIFF
--- a/porko-service/src/main/java/io/porko/friend/controller/FriendController.java
+++ b/porko-service/src/main/java/io/porko/friend/controller/FriendController.java
@@ -18,7 +18,7 @@ public class FriendController {
     private final FriendService friendService;
 
     @GetMapping
-    public ResponseEntity<List<FriendResponse>> getFriendList(@LoginMember Long id) {
-        return ResponseEntity.ok(friendService.getFriendList(id));
+    public ResponseEntity<FriendResponse> getFriendResponse(@LoginMember Long id) {
+        return ResponseEntity.ok(friendService.getFriendResponse(id));
     }
 }

--- a/porko-service/src/main/java/io/porko/friend/controller/model/FriendList.java
+++ b/porko-service/src/main/java/io/porko/friend/controller/model/FriendList.java
@@ -1,15 +1,15 @@
 package io.porko.friend.controller.model;
 
-public record FriendListResponse(
+public record FriendList(
         Long memberId,
         String name,
         String profileImageUrl
 ) {
-    public static FriendListResponse of (
+    public static FriendList of (
             Long memberId,
             String name,
             String profileImageUrl) {
-        return new FriendListResponse(
+        return new FriendList(
                 memberId,
                 name,
                 profileImageUrl);

--- a/porko-service/src/main/java/io/porko/friend/controller/model/FriendListResponse.java
+++ b/porko-service/src/main/java/io/porko/friend/controller/model/FriendListResponse.java
@@ -1,0 +1,17 @@
+package io.porko.friend.controller.model;
+
+public record FriendListResponse(
+        Long memberId,
+        String name,
+        String profileImageUrl
+) {
+    public static FriendListResponse of (
+            Long memberId,
+            String name,
+            String profileImageUrl) {
+        return new FriendListResponse(
+                memberId,
+                name,
+                profileImageUrl);
+    }
+}

--- a/porko-service/src/main/java/io/porko/friend/controller/model/FriendResponse.java
+++ b/porko-service/src/main/java/io/porko/friend/controller/model/FriendResponse.java
@@ -1,19 +1,12 @@
 package io.porko.friend.controller.model;
 
-import com.querydsl.core.annotations.QueryProjection;
+import java.util.List;
 
 public record FriendResponse(
-        Long memberId,
-        String name,
-        String profileImageUrl
+    int friendCount,
+    List<FriendListResponse> friendListResponse
 ) {
-    public static FriendResponse of (
-            Long memberId,
-            String name,
-            String profileImageUrl) {
-        return new FriendResponse(
-                memberId,
-                name,
-                profileImageUrl);
+    public static FriendResponse of (int friendCount, List<FriendListResponse> friendListResponse) {
+        return new FriendResponse(friendCount, friendListResponse);
     }
 }

--- a/porko-service/src/main/java/io/porko/friend/controller/model/FriendResponse.java
+++ b/porko-service/src/main/java/io/porko/friend/controller/model/FriendResponse.java
@@ -4,9 +4,9 @@ import java.util.List;
 
 public record FriendResponse(
     int friendCount,
-    List<FriendListResponse> friendListResponse
+    List<FriendList> friendList
 ) {
-    public static FriendResponse of (int friendCount, List<FriendListResponse> friendListResponse) {
-        return new FriendResponse(friendCount, friendListResponse);
+    public static FriendResponse of (int friendCount, List<FriendList> friendList) {
+        return new FriendResponse(friendCount, friendList);
     }
 }

--- a/porko-service/src/main/java/io/porko/friend/service/FriendService.java
+++ b/porko-service/src/main/java/io/porko/friend/service/FriendService.java
@@ -1,6 +1,6 @@
 package io.porko.friend.service;
 
-import io.porko.friend.controller.model.FriendListResponse;
+import io.porko.friend.controller.model.FriendList;
 import io.porko.friend.controller.model.FriendResponse;
 import io.porko.friend.domain.Friend;
 import io.porko.friend.repo.FriendRepo;
@@ -17,13 +17,13 @@ public class FriendService {
     private final FriendRepo friendRepo;
 
     public FriendResponse getFriendResponse(Long id) {
-        List<FriendListResponse> list = getFriendList(id);
+        List<FriendList> list = getFriendList(id);
 
         return FriendResponse.of(list.size(), list);
     }
 
-    public List<FriendListResponse> getFriendList(Long id) {
-        List<FriendListResponse> list = new ArrayList<>();
+    public List<FriendList> getFriendList(Long id) {
+        List<FriendList> list = new ArrayList<>();
 
         list.addAll(getFriendListByMemberId(id));
         list.addAll(getMemberListByFriendId(id));
@@ -31,22 +31,22 @@ public class FriendService {
         return list;
     }
 
-    public List<FriendListResponse> getFriendListByMemberId(Long id) {
+    public List<FriendList> getFriendListByMemberId(Long id) {
         List<Friend> friendList = friendRepo.findAllByIdMemberId(id);
 
         return friendList.stream()
-                .map(friend -> FriendListResponse.of(
+                .map(friend -> FriendList.of(
                         friend.getFriend().getId(),
                         friend.getFriend().getName(),
                         friend.getFriend().getProfileImageUrl()))
                 .collect(Collectors.toList());
     }
 
-    public List<FriendListResponse> getMemberListByFriendId(Long id) {
+    public List<FriendList> getMemberListByFriendId(Long id) {
         List<Friend> memberList = friendRepo.findAllByIdFriendId(id);
 
         return memberList.stream()
-                .map(friend -> FriendListResponse.of(
+                .map(friend -> FriendList.of(
                         friend.getMember().getId(),
                         friend.getMember().getName(),
                         friend.getMember().getProfileImageUrl()))

--- a/porko-service/src/main/java/io/porko/friend/service/FriendService.java
+++ b/porko-service/src/main/java/io/porko/friend/service/FriendService.java
@@ -1,5 +1,6 @@
 package io.porko.friend.service;
 
+import io.porko.friend.controller.model.FriendListResponse;
 import io.porko.friend.controller.model.FriendResponse;
 import io.porko.friend.domain.Friend;
 import io.porko.friend.repo.FriendRepo;
@@ -15,8 +16,14 @@ import java.util.stream.Collectors;
 public class FriendService {
     private final FriendRepo friendRepo;
 
-    public List<FriendResponse> getFriendList(Long id) {
-        List<FriendResponse> list = new ArrayList<>();
+    public FriendResponse getFriendResponse(Long id) {
+        List<FriendListResponse> list = getFriendList(id);
+
+        return FriendResponse.of(list.size(), list);
+    }
+
+    public List<FriendListResponse> getFriendList(Long id) {
+        List<FriendListResponse> list = new ArrayList<>();
 
         list.addAll(getFriendListByMemberId(id));
         list.addAll(getMemberListByFriendId(id));
@@ -24,22 +31,22 @@ public class FriendService {
         return list;
     }
 
-    public List<FriendResponse> getFriendListByMemberId(Long id) {
+    public List<FriendListResponse> getFriendListByMemberId(Long id) {
         List<Friend> friendList = friendRepo.findAllByIdMemberId(id);
 
         return friendList.stream()
-                .map(friend -> FriendResponse.of(
+                .map(friend -> FriendListResponse.of(
                         friend.getFriend().getId(),
                         friend.getFriend().getName(),
                         friend.getFriend().getProfileImageUrl()))
                 .collect(Collectors.toList());
     }
 
-    public List<FriendResponse> getMemberListByFriendId(Long id) {
+    public List<FriendListResponse> getMemberListByFriendId(Long id) {
         List<Friend> memberList = friendRepo.findAllByIdFriendId(id);
 
         return memberList.stream()
-                .map(friend -> FriendResponse.of(
+                .map(friend -> FriendListResponse.of(
                         friend.getMember().getId(),
                         friend.getMember().getName(),
                         friend.getMember().getProfileImageUrl()))


### PR DESCRIPTION
## #️⃣연관된 이슈
https://github.com/project-porko/porko-service/issues/147 공유 멤버 조회시 멤버 수 조회 기능 추가 구현

## 📝작업 내용
- 필드 추가로 인한 Response 분리
- [현재 사용자와 친구 상태인 멤버 수 조회 기능 구현](https://github.com/project-porko/porko-service/commit/a91d3f85641024177bb2e219bb06500b6dd947ea)