### PR TITLE
feat: 공유 멤버 조회시 현재 사용자 정보 추가

### DIFF
--- a/porko-service/src/main/java/io/porko/budget/service/BudgetService.java
+++ b/porko-service/src/main/java/io/porko/budget/service/BudgetService.java
@@ -30,15 +30,7 @@ public class BudgetService {
     private final HistoryQueryRepo historyQueryRepo;
 
     public BudgetResponse getBudget(Integer goalYear, Integer goalMonth, Long memberId) {
-        Budget budget = budgetRepo.findByGoalYearAndGoalMonthAndMemberId(goalYear, goalMonth, memberId).orElseThrow(() -> new BudgetException(BudgetErrorCode.BUDGET_NOT_SET, goalYear, goalMonth, memberId));
-
-        BigDecimal totalCost = historyQueryRepo.calcTotalCost(goalYear, goalMonth, memberId).orElse(BigDecimal.ZERO);
-
-        return BudgetResponse.of(totalCost.divide(budget.getGoalCost())
-                            .multiply(BigDecimal.valueOf(100))
-                            .abs()
-                            .setScale(1, RoundingMode.DOWN)
-                            .stripTrailingZeros());
+        return BudgetResponse.of(calcUsedBudget(goalYear, goalMonth, memberId));
     }
 
     @Transactional
@@ -114,5 +106,17 @@ public class BudgetService {
                 )
                 .stripTrailingZeros()
         ).orElse(null);
+    }
+
+    public BigDecimal calcUsedBudget (Integer goalYear, Integer goalMonth, Long memberId) {
+        Budget budget = budgetRepo.findByGoalYearAndGoalMonthAndMemberId(goalYear, goalMonth, memberId).orElseThrow(() -> new BudgetException(BudgetErrorCode.BUDGET_NOT_SET, goalYear, goalMonth, memberId));
+
+        BigDecimal totalCost = historyQueryRepo.calcTotalCost(goalYear, goalMonth, memberId).orElse(BigDecimal.ZERO);
+
+        return totalCost.divide(budget.getGoalCost())
+                .multiply(BigDecimal.valueOf(100))
+                .abs()
+                .setScale(1, RoundingMode.DOWN)
+                .stripTrailingZeros();
     }
 }

--- a/porko-service/src/main/java/io/porko/consumption/controller/ConsumptionController.java
+++ b/porko-service/src/main/java/io/porko/consumption/controller/ConsumptionController.java
@@ -2,6 +2,7 @@ package io.porko.consumption.controller;
 
 import io.porko.auth.controller.model.LoginMember;
 import io.porko.consumption.controller.model.RegretResponse;
+import io.porko.consumption.controller.model.WeatherResponse;
 import io.porko.consumption.service.ConsumptionService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
@@ -29,5 +30,17 @@ public class ConsumptionController {
         }
 
         return ResponseEntity.ok(consumptionService.makeRegretResponse(year, month, memberId));
+    }
+
+    @GetMapping("/weather")
+    public ResponseEntity<WeatherResponse> countWeather(@Valid @RequestParam int year,
+                                                        @Valid @RequestParam @Min(1) @Max(12) int month,
+                                                        @RequestParam(required = false) Long memberId,
+                                                        @LoginMember Long id) {
+        if (memberId == null) {
+            memberId = id;
+        }
+
+        return ResponseEntity.ok(consumptionService.makeWeatherResponse(year, month, memberId));
     }
 }

--- a/porko-service/src/main/java/io/porko/consumption/controller/model/WeatherListResponse.java
+++ b/porko-service/src/main/java/io/porko/consumption/controller/model/WeatherListResponse.java
@@ -1,0 +1,7 @@
+package io.porko.consumption.controller.model;
+
+public record WeatherListResponse(Integer weatherImageNo, int count) {
+    public WeatherListResponse of(Integer weatherImageNo, int count) {
+        return new WeatherListResponse(weatherImageNo, count);
+    }
+}

--- a/porko-service/src/main/java/io/porko/consumption/controller/model/WeatherListResponse.java
+++ b/porko-service/src/main/java/io/porko/consumption/controller/model/WeatherListResponse.java
@@ -1,7 +1,7 @@
 package io.porko.consumption.controller.model;
 
 public record WeatherListResponse(Integer weatherImageNo, int count) {
-    public WeatherListResponse of(Integer weatherImageNo, int count) {
+    public static WeatherListResponse of(Integer weatherImageNo, int count) {
         return new WeatherListResponse(weatherImageNo, count);
     }
 }

--- a/porko-service/src/main/java/io/porko/consumption/controller/model/WeatherListResponse.java
+++ b/porko-service/src/main/java/io/porko/consumption/controller/model/WeatherListResponse.java
@@ -1,7 +1,13 @@
 package io.porko.consumption.controller.model;
 
-public record WeatherListResponse(Integer weatherImageNo, int count) {
-    public static WeatherListResponse of(Integer weatherImageNo, int count) {
-        return new WeatherListResponse(weatherImageNo, count);
+public record WeatherListResponse(
+        Integer weatherImageNo,
+        String weatherName,
+        int count) {
+    public static WeatherListResponse of(
+            Integer weatherImageNo,
+            String weatherName,
+            int count) {
+        return new WeatherListResponse(weatherImageNo, weatherName, count);
     }
 }

--- a/porko-service/src/main/java/io/porko/consumption/controller/model/WeatherResponse.java
+++ b/porko-service/src/main/java/io/porko/consumption/controller/model/WeatherResponse.java
@@ -1,0 +1,17 @@
+package io.porko.consumption.controller.model;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record WeatherResponse(
+        String name,
+        BigDecimal used,
+        List<WeatherListResponse> weather
+) {
+    public WeatherResponse of (
+            String name,
+            BigDecimal used,
+            List<WeatherListResponse> weather) {
+        return new WeatherResponse(name, used, weather);
+    }
+}

--- a/porko-service/src/main/java/io/porko/consumption/controller/model/WeatherResponse.java
+++ b/porko-service/src/main/java/io/porko/consumption/controller/model/WeatherResponse.java
@@ -8,7 +8,7 @@ public record WeatherResponse(
         BigDecimal used,
         List<WeatherListResponse> weather
 ) {
-    public WeatherResponse of (
+    public static WeatherResponse of (
             String name,
             BigDecimal used,
             List<WeatherListResponse> weather) {


### PR DESCRIPTION
## #️⃣연관된 이슈
https://github.com/project-porko/porko-service/issues/152 공유 멤버 조회시 멤버 수 조회 기능 추가 구현

## 📝작업 내용
 - [ ] 공유 멤버 조회시 현재 사용자 추가
 - [ ] 프로필 이미지 URL 데이터 4,5 삭제