### PR TITLE
feat: 공유 멤버 조회시 멤버 수 조회 기능 추가 구현

### DIFF
--- a/porko-service/src/main/java/io/porko/friend/service/FriendService.java
+++ b/porko-service/src/main/java/io/porko/friend/service/FriendService.java
@@ -4,6 +4,8 @@ import io.porko.friend.controller.model.FriendList;
 import io.porko.friend.controller.model.FriendResponse;
 import io.porko.friend.domain.Friend;
 import io.porko.friend.repo.FriendRepo;
+import io.porko.member.domain.Member;
+import io.porko.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,9 +17,12 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class FriendService {
     private final FriendRepo friendRepo;
-
+    private final MemberService memberService;
     public FriendResponse getFriendResponse(Long id) {
-        List<FriendList> list = getFriendList(id);
+        List<FriendList> list = new ArrayList<>();
+
+        list.add(getCurrentMember(id));
+        list.addAll(getFriendList(id));
 
         return FriendResponse.of(list.size(), list);
     }
@@ -51,5 +56,14 @@ public class FriendService {
                         friend.getMember().getName(),
                         friend.getMember().getProfileImageUrl()))
                 .collect(Collectors.toList());
+    }
+
+    public FriendList getCurrentMember(Long currentMemberId) {
+        Member member = memberService.findMemberById(currentMemberId);
+
+        return FriendList.of(
+                member.getId(),
+                member.getName(),
+                member.getProfileImageUrl());
     }
 }

--- a/porko-service/src/main/resources/data.sql
+++ b/porko-service/src/main/resources/data.sql
@@ -6,9 +6,9 @@ values ('반포동', '서울시 서초구', '2024-05-21T03:29:30.044', 'project.
        ('신림동', '서울시 관악구', '2024-05-23T05:29:30.044', 'temp1234@gmail.com', 'MALE', '홍길동',
         '{bcrypt}$2a$10$8VSoF7WnqGiFDp0XPA93IuKtMLR17Tte6ROVBS8ORVX8nQnJjbJYS', '01055556666', null, '/images/default-profile/profile_3.jpg'),
        ('상도동', '서울시 동작구', '2024-05-25T06:29:30.044', 'testtest@gmail.com', 'MALE', '가나다',
-        '{bcrypt}$2a$10$8VSoF7WnqGiFDp0XPA93IuKtMLR17Tte6ROVBS8ORVX8nQnJjbJYS', '01077778888', null, '/images/default-profile/profile_4.jpg'),
+        '{bcrypt}$2a$10$8VSoF7WnqGiFDp0XPA93IuKtMLR17Tte6ROVBS8ORVX8nQnJjbJYS', '01077778888', null, '/images/default-profile/profile_1.jpg'),
        ('사당동', '서울시 동작구', '2024-05-21T04:29:30.044', 'thisistest@gmail.com', 'MALE', '라마바',
-        '{bcrypt}$2a$10$8VSoF7WnqGiFDp0XPA93IuKtMLR17Tte6ROVBS8ORVX8nQnJjbJYS', '01099990000', null, '/images/default-profile/profile_5.jpg');
+        '{bcrypt}$2a$10$8VSoF7WnqGiFDp0XPA93IuKtMLR17Tte6ROVBS8ORVX8nQnJjbJYS', '01099990000', null, '/images/default-profile/profile_2.jpg');
 
 
 


### PR DESCRIPTION
## #️⃣연관된 이슈
https://github.com/project-porko/porko-service/issues/152 공유 멤버 조회시 멤버 수 조회 기능 추가 구현

## 📝작업 내용
 - [공유 멤버 조회시 현재 사용자 정보 추가](https://github.com/project-porko/porko-service/commit/71544f61f36fa4678612fbd9be6e9456b809292c)
 - [프로필 이미지 더미 데이터 4,5 삭제](https://github.com/project-porko/porko-service/commit/4759e0de0c6622750a96d9b8056a492beffd9d00)