### PR TITLE
Feature#166 history date order

### DIFF
--- a/porko-service/src/main/java/io/porko/history/repo/HistoryRepo.java
+++ b/porko-service/src/main/java/io/porko/history/repo/HistoryRepo.java
@@ -11,7 +11,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface HistoryRepo extends JpaRepository<History, Long> {
-    Page<History> findByMemberIdAndUsedAtBetween(
+    Page<History> findByMemberIdAndUsedAtBetweenOrderByUsedAtDesc(
         Long memberId,
         LocalDateTime startDate,
         LocalDateTime endDate,

--- a/porko-service/src/main/java/io/porko/history/service/HistoryService.java
+++ b/porko-service/src/main/java/io/porko/history/service/HistoryService.java
@@ -71,7 +71,7 @@ public class HistoryService {
         BigDecimal totalSpent = historyRepo.calcSpentCostForPeriod(loginMemberId, startDateTime, endDateTime).orElse(BigDecimal.ZERO);
         BigDecimal totalEarned = historyRepo.calcEarnedCostForPeriod(loginMemberId, startDateTime, endDateTime).orElse(BigDecimal.ZERO);
 
-        Page<History> histories = historyRepo.findByMemberIdAndUsedAtBetween(loginMemberId, startDateTime, endDateTime, pageable);
+        Page<History> histories = historyRepo.findByMemberIdAndUsedAtBetweenOrderByUsedAtDesc(loginMemberId, startDateTime, endDateTime, pageable);
 
         List<HistoryResponse> historyResponses = histories.stream()
             .map(HistoryResponse::of)


### PR DESCRIPTION
## #️⃣연관된 이슈
https://github.com/project-porko/porko-service/issues/166 입출금내역 날짜 출력 순서 변경 

## 📝작업 내용
- [HistoryService 입출금내역 날짜출력 순서 내림차순정렬 추가](https://github.com/project-porko/porko-service/pull/167/commits/1224c3f3faa996240a06405029baffd716865377)
- [HistoryRepo 입출금내역 날짜출력 순서 내림차순으로 변경.](https://github.com/project-porko/porko-service/pull/167/commits/439ac97a9b363324b2cfb8f88b5c20dc3472f1b9)

HistoryRepo ,HistoryService 입출금내역 날짜출력 순서 내림차순정렬 추가 및 서비스 클래스 업데이트

변경 사항:
- Repository 클래스에서 findByMemberIdAndUsedAtBetween 메서드를 findByMemberIdAndUsedAtBetweenOrderByUsedAtDesc 메서드로 수정하여, 조회 결과가 usedAt 필드 기준으로 내림차순 정렬되도록 변경되었습니다.
- HistoryService 클래스의 fetchHistoryList 메서드에서도 변경된 Repository 메서드를 사용하도록 업데이트했습니다.

변경 이유:
- 사용 이력 조회 시 최근 사용 내역을 먼저 보여주기 위해 정렬 기준을 추가했습니다.