### PR TITLE
fix: 목표 예산 조회시 예산 초과 데이터 조회 수정

### DIFF
--- a/porko-service/src/main/java/io/porko/budget/service/BudgetService.java
+++ b/porko-service/src/main/java/io/porko/budget/service/BudgetService.java
@@ -89,7 +89,7 @@ public class BudgetService {
                         today.getYear(),
                         today.getMonthValue(),
                         memberId,
-                        dailyCost),
+                        budget.getGoalCost().divide(BigDecimal.valueOf(lastDayOfMonth), 0, RoundingMode.DOWN)),
                 today.getDayOfMonth() - historyQueryRepo.countSpendingDate(
                         today.getYear(),
                         today.getMonthValue(),

--- a/porko-service/src/main/java/io/porko/history/repo/HistoryQueryRepo.java
+++ b/porko-service/src/main/java/io/porko/history/repo/HistoryQueryRepo.java
@@ -29,7 +29,7 @@ public class HistoryQueryRepo {
                 .fetchOne());
     }
 
-    public Long countOverSpend(Integer goalYear, Integer goalMonth, Long memberId, BigDecimal dailyCost) {
+    public Long countOverSpend(Integer goalYear, Integer goalMonth, Long memberId, BigDecimal dailyBudget) {
         return Long.valueOf(queryFactory.select()
                 .from(history)
                 .where(history.member.id.eq(memberId)
@@ -37,7 +37,7 @@ public class HistoryQueryRepo {
                         .and(history.usedAt.year().eq(goalYear))
                         .and(history.usedAt.month().eq(goalMonth))
                         .and(history.usedAt.dayOfMonth().lt(LocalDate.now().getDayOfMonth()))
-                        .and(history.cost.gt(dailyCost)))
+                        .and(history.cost.abs().gt(dailyBudget)))
                 .fetchCount());
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
https://github.com/project-porko/porko-service/issues/185 목표 예산 조회시 예산 초과 데이터 조회 수정

## 📝작업 내용
- [하루 예산 계산 방법 변경](https://github.com/project-porko/porko-service/commit/3f2373d822026091676ea0626dfd58932e6ef457)
- [하루 예산 초과 일 수 조회 쿼리 수정](https://github.com/project-porko/porko-service/commit/7ec3bf6aa2826acfb33f3800cceb40203f75993b)