### PR TITLE
chore:(#191): HistoryController, repo, service에 정렬 기능 코드 추가 및 코드 정리

### DIFF
--- a/porko-service/src/main/java/io/porko/domain/history/controller/HistoryController.java
+++ b/porko-service/src/main/java/io/porko/domain/history/controller/HistoryController.java
@@ -15,6 +15,8 @@ import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.SortDefault;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -35,7 +37,9 @@ public class HistoryController {
         @LoginMember Long loginMemberId,
         @RequestParam(value = "startDate", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
         @RequestParam(value = "endDate", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
-        @Pagination Pageable pagination
+        @Pagination
+        @SortDefault(sort ="usedAt", direction = Sort.Direction.DESC)
+        Pageable pagination
     ) {
         if (startDate == null || endDate == null) {
             return ResponseEntity.ok(historyService.getThisMonthHistoryList(loginMemberId, pagination));

--- a/porko-service/src/main/java/io/porko/domain/history/repo/HistoryRepo.java
+++ b/porko-service/src/main/java/io/porko/domain/history/repo/HistoryRepo.java
@@ -11,7 +11,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface HistoryRepo extends JpaRepository<History, Long> {
-    Page<History> findByMemberIdAndUsedAtBetweenOrderByUsedAtDesc(
+    Page<History> findByMemberIdAndUsedAtBetween(
         Long memberId,
         LocalDateTime startDate,
         LocalDateTime endDate,

--- a/porko-service/src/main/java/io/porko/domain/history/service/HistoryService.java
+++ b/porko-service/src/main/java/io/porko/domain/history/service/HistoryService.java
@@ -70,7 +70,7 @@ public class HistoryService {
         BigDecimal totalSpent = historyRepo.calcSpentCostForPeriod(loginMemberId, startDateTime, endDateTime).orElse(BigDecimal.ZERO);
         BigDecimal totalEarned = historyRepo.calcEarnedCostForPeriod(loginMemberId, startDateTime, endDateTime).orElse(BigDecimal.ZERO);
 
-        Page<History> histories = historyRepo.findByMemberIdAndUsedAtBetweenOrderByUsedAtDesc(loginMemberId, startDateTime, endDateTime, pageable);
+        Page<History> histories = historyRepo.findByMemberIdAndUsedAtBetween(loginMemberId, startDateTime, endDateTime, pageable);
 
         List<HistoryResponse> historyResponses = histories.stream()
             .map(HistoryResponse::of)


### PR DESCRIPTION
Pageable을 사용한 동적 정렬 설정 수정
[#191](https://github.com/project-porko/porko-service/issues/191)

변경사항:
- 중복된 findByMemberIdAndUsedAtBetweenOrderByUsedAtDesc 메서드 제거.
- @Pagination 어노테이션 사용을 반영하여 컨트롤러에서 정렬 기능 지원.
- fetchHistoryList 메서드에서 중복된 findByMemberIdAndUsedAtBetweenOrderByUsedAtDesc 메서드를 findByMemberIdAndUsedAtBetween 메서드로 대체.
