### PR TITLE
chore:(#194): History엔티티, response HistoryCategory 필드명 변경

### DIFF
--- a/porko-service/src/main/java/io/porko/domain/history/controller/model/HistoryDetailResponse.java
+++ b/porko-service/src/main/java/io/porko/domain/history/controller/model/HistoryDetailResponse.java
@@ -10,7 +10,7 @@ public record HistoryDetailResponse(
         LocalDateTime usedAt,
         BigDecimal cost,
         String place,
-        HistoryCategory historyCategoryId,
+        HistoryCategory historyCategory,
         String payType,
         boolean isRegret,
         String memo
@@ -21,7 +21,7 @@ public record HistoryDetailResponse(
                 history.getUsedAt(),
                 history.getCost(),
                 history.getPlace(),
-                history.getHistoryCategoryId(),
+                history.getHistoryCategory(),
                 history.getPayType(),
                 history.isRegret(),
                 history.getMemo()

--- a/porko-service/src/main/java/io/porko/domain/history/controller/model/HistoryResponse.java
+++ b/porko-service/src/main/java/io/porko/domain/history/controller/model/HistoryResponse.java
@@ -12,7 +12,7 @@ public record HistoryResponse(
         LocalDateTime usedAt,
         BigDecimal cost,
         String place,
-        HistoryCategory historyCategoryId,
+        HistoryCategory historyCategory,
         String payType,
         boolean isRegret
 
@@ -27,7 +27,7 @@ public record HistoryResponse(
                 history.getUsedAt(),
                 history.getCost(),
                 history.getPlace(),
-                history.getHistoryCategoryId(),
+                history.getHistoryCategory(),
                 history.getPayType(),
                 history.isRegret()
         );

--- a/porko-service/src/main/java/io/porko/domain/history/domain/History.java
+++ b/porko-service/src/main/java/io/porko/domain/history/domain/History.java
@@ -41,7 +41,7 @@ public class History {
     private LocalDateTime usedAt;
 
     @Embedded
-    private HistoryCategory historyCategoryId;
+    private HistoryCategory historyCategory;
 
     @Column(length = 100)
     private String memo;
@@ -60,7 +60,7 @@ public class History {
         String place,
         String payType,
         LocalDateTime usedAt,
-        HistoryCategory historyCategoryId,
+        HistoryCategory historyCategory,
         Member member
     ) {
         this.cost = cost;
@@ -68,7 +68,7 @@ public class History {
         this.place = place;
         this.payType = payType;
         this.usedAt = usedAt;
-        this.historyCategoryId = historyCategoryId;
+        this.historyCategory = historyCategory;
         this.member = member;
     }
 
@@ -78,7 +78,7 @@ public class History {
         String place,
         String payType,
         LocalDateTime usedAt,
-        HistoryCategory historyCategoryId,
+        HistoryCategory historyCategory,
         Member member
     ) {
         return new History(
@@ -87,7 +87,7 @@ public class History {
             place,
             payType,
             usedAt,
-            historyCategoryId,
+            historyCategory,
             member
         );
     }


### PR DESCRIPTION
HistoryCategory 필드명 변경
[#194](https://github.com/project-porko/porko-service/issues/194)

변경내용:
historyCategoryId에서 historyCategory로 변경.

변경사유:
코드 가독성과 명명 규칙의 일관성을 향상시킴.